### PR TITLE
fix none organization name

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,6 +22,19 @@
             "command": "docker build -t xiaoyao9184/olah:0.3.3 -f ./docker/build@pypi/dockerfile .",
         },
         {
+            "label": "huggingface-cli: download bert-base-uncased",
+            "type": "shell",
+            "options": {
+                "cwd": "${workspaceFolder}",
+                "env": {
+                    "HF_ENDPOINT": "http://localhost:18090",
+                    "HF_HUB_ETAG_TIMEOUT": "100",
+                    "HF_HUB_DOWNLOAD_TIMEOUT": "100"
+                }
+            },
+            "command": "huggingface-cli download bert-base-uncased --revision main --cache-dir ./cache/huggingface/hub"
+        },
+        {
             "label": "huggingface-cli: download cais/mmlu",
             "type": "shell",
             "options": {

--- a/olah/proxy/commits.py
+++ b/olah/proxy/commits.py
@@ -80,10 +80,11 @@ async def commits_generator(
     if authorization is not None:
         headers["authorization"] = authorization
 
+    org_repo = get_org_repo(org, repo)
     # save
     repos_path = app.app_settings.config.repos_path
     save_dir = os.path.join(
-        repos_path, f"api/{repo_type}/{org}/{repo}/commits/{commit}"
+        repos_path, f"api/{repo_type}/{org_repo}/commits/{commit}"
     )
     save_path = os.path.join(save_dir, f"commits_{method}.json")
 

--- a/olah/proxy/files.py
+++ b/olah/proxy/files.py
@@ -468,10 +468,10 @@ async def file_get_generator(
     # save
     repos_path = app.app_settings.config.repos_path
     head_path = os.path.join(
-        repos_path, f"heads/{repo_type}/{org}/{repo}/resolve/{commit}/{file_path}"
+        repos_path, f"heads/{repo_type}/{org_repo}/resolve/{commit}/{file_path}"
     )
     save_path = os.path.join(
-        repos_path, f"files/{repo_type}/{org}/{repo}/resolve/{commit}/{file_path}"
+        repos_path, f"files/{repo_type}/{org_repo}/resolve/{commit}/{file_path}"
     )
     make_dirs(head_path)
     make_dirs(save_path)
@@ -522,10 +522,10 @@ async def cdn_file_get_generator(
     # save
     repos_path = app.app_settings.config.repos_path
     head_path = os.path.join(
-        repos_path, f"heads/{repo_type}/{org}/{repo}/cdn/{file_hash}"
+        repos_path, f"heads/{repo_type}/{org_repo}/cdn/{file_hash}"
     )
     save_path = os.path.join(
-        repos_path, f"files/{repo_type}/{org}/{repo}/cdn/{file_hash}"
+        repos_path, f"files/{repo_type}/{org_repo}/cdn/{file_hash}"
     )
     make_dirs(head_path)
     make_dirs(save_path)

--- a/olah/proxy/meta.py
+++ b/olah/proxy/meta.py
@@ -76,10 +76,11 @@ async def meta_generator(
     if authorization is not None:
         headers["authorization"] = authorization
 
+    org_repo = get_org_repo(org, repo)
     # save
     repos_path = app.app_settings.config.repos_path
     save_dir = os.path.join(
-        repos_path, f"api/{repo_type}/{org}/{repo}/revision/{commit}"
+        repos_path, f"api/{repo_type}/{org_repo}/revision/{commit}"
     )
     save_path = os.path.join(save_dir, f"meta_{method}.json")
     make_dirs(save_path)

--- a/olah/proxy/pathsinfo.py
+++ b/olah/proxy/pathsinfo.py
@@ -72,13 +72,14 @@ async def pathsinfo_generator(
     if authorization is not None:
         headers["authorization"] = authorization
 
+    org_repo = get_org_repo(org, repo)
     # save
     repos_path = app.app_settings.config.repos_path
 
     final_content = []
     for path in paths:
         save_dir = os.path.join(
-            repos_path, f"api/{repo_type}/{org}/{repo}/paths-info/{commit}/{path}"
+            repos_path, f"api/{repo_type}/{org_repo}/paths-info/{commit}/{path}"
         )
 
         save_path = os.path.join(save_dir, f"paths-info_{method}.json")

--- a/olah/proxy/tree.py
+++ b/olah/proxy/tree.py
@@ -82,10 +82,11 @@ async def tree_generator(
     if authorization is not None:
         headers["authorization"] = authorization
 
+    org_repo = get_org_repo(org, repo)
     # save
     repos_path = app.app_settings.config.repos_path
     save_dir = os.path.join(
-        repos_path, f"api/{repo_type}/{org}/{repo}/tree/{commit}/{path}"
+        repos_path, f"api/{repo_type}/{org_repo}/tree/{commit}/{path}"
     )
     save_path = os.path.join(save_dir, f"tree_{method}_recursive_{recursive}_expand_{expand}.json")
 

--- a/olah/server.py
+++ b/olah/server.py
@@ -193,7 +193,7 @@ async def meta_proxy_common(repo_type: str, org: str, repo: str, commit: str, me
     # Check Mirror Path
     for mirror_path in app.app_settings.config.mirrors_path:
         try:
-            git_path = os.path.join(mirror_path, repo_type, org, repo)
+            git_path = os.path.join(mirror_path, repo_type, org or '', repo)
             if os.path.exists(git_path):
                 local_repo = LocalMirrorRepo(git_path, repo_type, org, repo)
                 meta_data = local_repo.get_meta(commit)
@@ -370,7 +370,7 @@ async def tree_proxy_common(
     # Check Mirror Path
     for mirror_path in app.app_settings.config.mirrors_path:
         try:
-            git_path = os.path.join(mirror_path, repo_type, org, repo)
+            git_path = os.path.join(mirror_path, repo_type, org or '', repo)
             if os.path.exists(git_path):
                 local_repo = LocalMirrorRepo(git_path, repo_type, org, repo)
                 tree_data = local_repo.get_tree(commit, path, recursive=recursive, expand=expand)
@@ -514,7 +514,7 @@ async def pathsinfo_proxy_common(repo_type: str, org: str, repo: str, commit: st
     # Check Mirror Path
     for mirror_path in app.app_settings.config.mirrors_path:
         try:
-            git_path = os.path.join(mirror_path, repo_type, org, repo)
+            git_path = os.path.join(mirror_path, repo_type, org or '', repo)
             if os.path.exists(git_path):
                 local_repo = LocalMirrorRepo(git_path, repo_type, org, repo)
                 pathsinfo_data = local_repo.get_pathinfos(commit, paths)
@@ -641,7 +641,7 @@ async def commits_proxy_common(repo_type: str, org: str, repo: str, commit: str,
     # Check Mirror Path
     for mirror_path in app.app_settings.config.mirrors_path:
         try:
-            git_path = os.path.join(mirror_path, repo_type, org, repo)
+            git_path = os.path.join(mirror_path, repo_type, org or '', repo)
             if os.path.exists(git_path):
                 local_repo = LocalMirrorRepo(git_path, repo_type, org, repo)
                 commits_data = local_repo.get_commits(commit)
@@ -789,7 +789,7 @@ async def file_head_common(
     # Check Mirror Path
     for mirror_path in app.app_settings.config.mirrors_path:
         try:
-            git_path = os.path.join(mirror_path, repo_type, org, repo)
+            git_path = os.path.join(mirror_path, repo_type, org or '', repo)
             if os.path.exists(git_path):
                 local_repo = LocalMirrorRepo(git_path, repo_type, org, repo)
                 head = local_repo.get_file_head(commit_hash=commit, path=file_path)
@@ -924,7 +924,7 @@ async def file_get_common(
     # Check Mirror Path
     for mirror_path in app.app_settings.config.mirrors_path:
         try:
-            git_path = os.path.join(mirror_path, repo_type, org, repo)
+            git_path = os.path.join(mirror_path, repo_type, org or '', repo)
             if os.path.exists(git_path):
                 local_repo = LocalMirrorRepo(git_path, repo_type, org, repo)
                 content_stream = local_repo.get_file(commit_hash=commit, path=file_path)

--- a/olah/utils/repo_utils.py
+++ b/olah/utils/repo_utils.py
@@ -74,8 +74,9 @@ def get_meta_save_path(
         The path to save the meta.json file as a string.
 
     """
+    org_repo = get_org_repo(org, repo)
     return os.path.join(
-        repos_path, f"api/{repo_type}/{org}/{repo}/revision/{commit}/meta_get.json"
+        repos_path, f"api/{repo_type}/{org_repo}/revision/{commit}/meta_get.json"
     )
 
 
@@ -95,7 +96,8 @@ def get_meta_save_dir(
         The directory path to save the meta.json file as a string.
 
     """
-    return os.path.join(repos_path, f"api/{repo_type}/{org}/{repo}/revision")
+    org_repo = get_org_repo(org, repo)
+    return os.path.join(repos_path, f"api/{repo_type}/{org_repo}/revision")
 
 
 def get_file_save_path(
@@ -121,8 +123,9 @@ def get_file_save_path(
         The path to save the file as a string.
 
     """
+    org_repo = get_org_repo(org, repo)
     return os.path.join(
-        repos_path, f"heads/{repo_type}/{org}/{repo}/resolve_head/{commit}/{file_path}"
+        repos_path, f"heads/{repo_type}/{org_repo}/resolve_head/{commit}/{file_path}"
     )
 
 
@@ -183,8 +186,9 @@ async def get_newest_commit_hf(
         The newest commit hash as a string, or None if it cannot be obtained.
 
     """
+    org_repo = get_org_repo(org, repo)
     url = urljoin(
-        app.app_settings.config.hf_url_base(), f"/api/{repo_type}/{org}/{repo}"
+        app.app_settings.config.hf_url_base(), f"/api/{repo_type}/{org_repo}"
     )
     if app.app_settings.config.offline:
         return await get_newest_commit_hf_offline(app, repo_type, org, repo)


### PR DESCRIPTION
Early models with empty organization names, such as [bert-base-uncased](https://huggingface.co/bert-base-uncased), have been redirected to new names with organization . 

However, some projects still use models without specifying an organization. 
This causes an error like
```python
git_path = os.path.join(mirror_path, repo_type, org, repo)
```
when `org` is None. 

To prevent the issue of having paths like `api/models/None/bert-base-uncased` which can be confusing, 
the path
```python
f"api/{repo_type}/{org}/{repo}/tree/{commit}/{path}"
```
is replaced with
```python
f"api/{repo_type}/{org_repo}/tree/{commit}/{path}"
```

PS: Although this resolves the error, it introduces another issue where the same model could be cached multiple times under different names. Perhaps, based on the returned 307 status code, the org value could be replaced, allowing olah to support redirects in the configuration?