### PR TITLE
Fix incorrect ETag for non git-lfs in mirrors-path.

### DIFF
--- a/olah/mirror/repos.py
+++ b/olah/mirror/repos.py
@@ -319,7 +319,7 @@ class LocalMirrorRepo(object):
             header = {}
             header["content-length"] = str(commit.tree[path].data_stream.size)
             header["x-repo-commit"] = commit.hexsha
-            header["etag"] = self._sha256(commit.tree[path].data_stream.read())
+            header["etag"] = commit.tree[path].binsha.hex()
             return header
 
     def get_file(self, commit_hash: str, path: str) -> Optional[OStream]:


### PR DESCRIPTION
According to HF Hub Python Library reference, blobs is identified by git-sha (non git-lfs) or sha256 (git-lfs).

Return git-sha as the ETag by default. git-lfs is handled separately.