### PR TITLE
Add brotli to deps, olah-cli no longer runs without it

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "fastapi", "fastapi-utils", "httpx", "numpy", "pydantic<=2.8.2", "pydantic-settings<=2.4.0", "requests", "toml",
     "rich>=10.0.0", "shortuuid", "uvicorn", "tenacity>=8.2.2", "pytz", "cachetools", "GitPython",
     "PyYAML", "typing_inspect>=0.9.0", "huggingface_hub", "jinja2", "python-multipart", "portalocker",
-    "aiofiles"
+    "aiofiles", "brotli"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
In #47, there seemed to be a time when `brotli` was an optional library. I've just started using `olah` and I've noticed that it's no longer optional:

```sh
olah git:(47) ✗ python3 -m venv venv     
olah git:(47) ✗ source venv/bin/activate
olah git:(47) ✗ pip install --upgrade pip
olah git:(47) ✗ pip install -e .
olah git:(47) ✗ olah-cli
Traceback (most recent call last):
  File "/Users/rhartje/src/olah/venv/bin/olah-cli", line 5, in <module>
    from olah.server import cli
  File "/Users/rhartje/src/olah/src/olah/server.py", line 59, in <module>
    from olah.proxy.files import cdn_file_get_generator, file_get_generator
  File "/Users/rhartje/src/olah/src/olah/proxy/files.py", line 43, in <module>
    from olah.utils.zip_utils import Decompressor, decompress_data
  File "/Users/rhartje/src/olah/src/olah/utils/zip_utils.py", line 12, in <module>
    import brotli
ModuleNotFoundError: No module named 'brotli'    
```

For this reason, I've added brotli to `pyproject.toml` as a dependency:

```sh
olah git:(47) ✗ pip install -e . 
olah git:(47) ✗ olah-cli        
2025-07-15 17:59:20 | INFO | stdout | Namespace(config='', host='localhost', port=8090, hf_scheme='https', hf_netloc='huggingface.co', hf_lfs_netloc='cdn-lfs.huggingface.co', mirror_scheme='http', mirror_netloc='localhost:8090', mirror_lfs_netloc='localhost:8090', has_lfs_site=False, ssl_key=None, ssl_cert=None, repos_path='./repos', cache_size_limit=None, cache_clean_strategy='LRU', log_path='./logs')
2025-07-15 17:59:20 | INFO | stdout | Namespace(config='', host='localhost', port=8090, hf_scheme='https', hf_netloc='huggingface.co', hf_lfs_netloc='cdn-lfs.huggingface.co', mirror_scheme='http', mirror_netloc='localhost:8090', mirror_lfs_netloc='localhost:8090', has_lfs_site=False, ssl_key=None, ssl_cert=None, repos_path='./repos', cache_size_limit=None, cache_clean_strategy='LRU', log_path='./logs')
2025-07-15 17:59:20 | ERROR | stderr | INFO:     Started server process [48914]
2025-07-15 17:59:20 | ERROR | stderr | INFO:     Waiting for application startup.
2025-07-15 17:59:20 | ERROR | stderr | INFO:     Application startup complete.
2025-07-15 17:59:20 | ERROR | stderr | INFO:     Uvicorn running on http://localhost:8090 (Press CTRL+C to quit)
2025-07-15 17:59:20 | INFO | httpx | HTTP Request: HEAD https://huggingface.co/datasets/Salesforce/wikitext/resolve/main/.gitattributes "HTTP/1.1 307 Temporary Redirect"
2025-07-15 17:59:20 | ERROR | stderr | Failed to reach Huggingface Site.
```

I noticed the upstream docker image `xiahan2019/olah:lastet ` is broken as a result, as is the latest image release:
```sh
olah git:(47) ✗ docker run xiahan2019/olah:lastet
Traceback (most recent call last):
  File "/usr/local/bin/olah-cli", line 5, in <module>
    from olah.server import cli
  File "/usr/local/lib/python3.12/site-packages/olah/server.py", line 59, in <module>
    from olah.proxy.files import cdn_file_get_generator, file_get_generator
  File "/usr/local/lib/python3.12/site-packages/olah/proxy/files.py", line 43, in <module>
    from olah.utils.zip_utils import Decompressor, decompress_data
  File "/usr/local/lib/python3.12/site-packages/olah/utils/zip_utils.py", line 12, in <module>
    import brotli
ModuleNotFoundError: No module named 'brotli'

olah git:(47) ✗ docker run xiahan2019/olah:0.4.1
Traceback (most recent call last):
  File "/usr/local/bin/olah-cli", line 5, in <module>
    from olah.server import cli
  File "/usr/local/lib/python3.12/site-packages/olah/server.py", line 59, in <module>
    from olah.proxy.files import cdn_file_get_generator, file_get_generator
  File "/usr/local/lib/python3.12/site-packages/olah/proxy/files.py", line 43, in <module>
    from olah.utils.zip_utils import Decompressor, decompress_data
  File "/usr/local/lib/python3.12/site-packages/olah/utils/zip_utils.py", line 12, in <module>
    import brotli
ModuleNotFoundError: No module named 'brotli'
```

Looking at the image build pipeline, it looks like the tag would need to be pushed again to fix it in the release tag, but the `lastet` build should update at least and fix this for anyone using the docker compose file. 