### PR TITLE
Add Xet protocol pass-through for files >50 GB

### DIFF
--- a/src/olah/proxy/files.py
+++ b/src/olah/proxy/files.py
@@ -46,10 +46,20 @@ from olah.utils.zip_utils import Decompressor, decompress_data
 from olah.proxy.result import ProxyResult, single_chunk_body
 
 
+XET_RESPONSE_HEADERS = (
+    "x-xet-hash",
+    "x-xet-refresh-route",
+    "x-linked-size",
+    "x-linked-etag",
+    "link",
+)
+
+
 @dataclass(frozen=True)
 class RemoteFileMetadata:
     file_size: int
     etag: Optional[str]
+    xet_headers: Optional[Dict[str, str]] = None
 
 
 def get_block_info(pos: int, block_size: int, file_size: int) -> Tuple[int, int, int]:
@@ -454,12 +464,86 @@ async def _remote_file_metadata(
 
     content_length = response.headers.get("content-length")
     if content_length is None:
+        # Xet-only files have no content-length in the resolve HEAD; fall back to x-linked-size.
+        content_length = response.headers.get("x-linked-size")
+    if content_length is None:
         return None
     try:
         file_size = int(content_length)
     except ValueError:
         return None
-    return RemoteFileMetadata(file_size=file_size, etag=response.headers.get("etag"))
+    xet_headers = {h: response.headers[h] for h in XET_RESPONSE_HEADERS if h in response.headers}
+    return RemoteFileMetadata(
+        file_size=file_size,
+        etag=response.headers.get("etag") or response.headers.get("x-linked-etag"),
+        xet_headers=xet_headers or None,
+    )
+
+
+async def _detect_xet_passthrough(
+    hf_url: str,
+    authorization: Optional[str],
+    commit: Optional[str],
+) -> Optional[ProxyResult]:
+    # Xet files cannot stream through olah: the client must speak the Xet
+    # chunked protocol against xethub.hf.co directly. Probe upstream with a
+    # HEAD that follows *relative* redirects only (matching what
+    # huggingface_hub does), and stops at the first absolute 3xx — that is
+    # the response carrying x-xet-hash for renamed/canonical-redirected repos.
+    headers = {}
+    if authorization is not None:
+        headers["authorization"] = authorization
+    response = None
+    current_url = hf_url
+    try:
+        async with httpx.AsyncClient() as client:
+            for _ in range(5):
+                response = await client.request(
+                    method="HEAD",
+                    url=current_url,
+                    headers=headers,
+                    timeout=WORKER_API_TIMEOUT,
+                    follow_redirects=False,
+                )
+                if not (300 <= response.status_code < 400):
+                    break
+                location = response.headers.get("location")
+                if location is None:
+                    break
+                if urlparse(location).netloc:
+                    # Absolute redirect — this is where Xet metadata lives.
+                    break
+                # Use RFC 3986 reference resolution so the redirect's query
+                # string (or absence thereof) replaces the base's, instead of
+                # the half-baked path-only swap urlparse._replace would do.
+                current_url = urljoin(current_url, location)
+            else:
+                return None
+    except (httpx.HTTPError, ValueError):
+        return None
+    if response is None or "x-xet-hash" not in response.headers:
+        return None
+    response_headers: Dict[str, str] = {"accept-ranges": "bytes"}
+    for h in XET_RESPONSE_HEADERS:
+        if h in response.headers:
+            response_headers[h] = response.headers[h]
+    # huggingface_hub's _httpx_follow_relative_redirects_with_backoff raises
+    # KeyError on a 3xx response without a Location header. Upstream's Location
+    # is an absolute CAS bridge URL — the client won't follow it (only relative
+    # redirects are followed) but the header must still be present.
+    for h in ("etag", "content-length", "content-type", "location"):
+        if h in response.headers:
+            response_headers[h] = response.headers[h]
+    if commit is not None:
+        response_headers[HUGGINGFACE_HEADER_X_REPO_COMMIT.lower()] = commit
+    elif "x-repo-commit" in response.headers:
+        response_headers["x-repo-commit"] = response.headers["x-repo-commit"]
+    return ProxyResult(
+        status_code=response.status_code,
+        headers=response_headers,
+        body=single_chunk_body(b""),
+    )
+
 
 async def _file_realtime_stream(
     app,
@@ -511,6 +595,16 @@ async def _file_realtime_stream(
         request_headers["host"] = urlparse(hf_url).netloc
 
     authorization = request.headers.get("authorization", None)
+
+    if not app.state.app_settings.config.offline:
+        xet_passthrough = await _detect_xet_passthrough(
+            hf_url=hf_url,
+            authorization=authorization,
+            commit=commit,
+        )
+        if xet_passthrough is not None:
+            return xet_passthrough
+
     if repo_type is not None and org is not None and repo is not None and file_path is not None and commit is not None:
         generator = await pathsinfo_generator(
             app,

--- a/src/olah/server_api_routes.py
+++ b/src/olah/server_api_routes.py
@@ -291,6 +291,58 @@ async def whoami_v2(request: Request):
     )
 
 
+async def _xet_read_token_passthrough(repo_type: str, org_repo: str, commit: str, request: Request) -> Response:
+    # The Xet client refreshes its CAS access token by calling
+    # /api/<repo_type>/<org>/<repo>/xet-read-token/<commit> on the configured HF
+    # endpoint. With HF_ENDPOINT pointed at olah, that GET lands here, so we
+    # forward it verbatim to upstream HF — but only after the same access
+    # policy gate the file-resolve routes apply, otherwise this route would
+    # silently bypass mirror rules for any repo upstream is willing to grant.
+    repo_ref = parse_repo_ref(repo_type, org_repo)
+    if repo_ref is None:
+        return error_repo_not_found()
+    access_error = await ensure_repo_visibility(request.app, repo_ref, request.headers.get("authorization", None))
+    if access_error is not None:
+        return access_error
+    target = urljoin(
+        request.app.state.app_settings.config.hf_url_base(),
+        f"/api/{repo_type}/{org_repo}/xet-read-token/{commit}",
+    )
+    upstream_headers = {k.lower(): v for k, v in request.headers.items()}
+    upstream_headers["host"] = request.app.state.app_settings.config.hf_netloc
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.request(
+                method=request.method,
+                url=target,
+                headers=upstream_headers,
+                timeout=10,
+            )
+    except httpx.HTTPError:
+        return Response(status_code=504)
+    response_headers = {k.lower(): v for k, v in response.headers.items()}
+    response_headers.pop("content-encoding", None)
+    response_headers.pop("content-length", None)
+    response_headers.pop("transfer-encoding", None)
+    return Response(
+        content=response.content,
+        status_code=response.status_code,
+        headers=response_headers,
+    )
+
+
+@router.head("/api/{repo_type}/{org}/{repo}/xet-read-token/{commit}")
+@router.get("/api/{repo_type}/{org}/{repo}/xet-read-token/{commit}")
+async def xet_read_token_expanded(repo_type: str, org: str, repo: str, commit: str, request: Request):
+    return await _xet_read_token_passthrough(repo_type, f"{org}/{repo}", commit, request)
+
+
+@router.head("/api/{repo_type}/{org_repo}/xet-read-token/{commit}")
+@router.get("/api/{repo_type}/{org_repo}/xet-read-token/{commit}")
+async def xet_read_token_compact(repo_type: str, org_repo: str, commit: str, request: Request):
+    return await _xet_read_token_passthrough(repo_type, org_repo, commit, request)
+
+
 @router.head("/api/{repo_type}/{org_repo}")
 @router.get("/api/{repo_type}/{org_repo}")
 async def meta_proxy_compact(repo_type: str, org_repo: str, request: Request):

--- a/tests/test_xet_passthrough.py
+++ b/tests/test_xet_passthrough.py
@@ -1,0 +1,588 @@
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from fastapi import Request
+
+
+def _ensure_portalocker_stub():
+    if "portalocker" in sys.modules:
+        return
+    portalocker_stub = types.ModuleType("portalocker")
+
+    class _Lock:
+        def __init__(self, *args, **kwargs):
+            self._fh = open(args[0], kwargs.get("mode", "a+b"))
+
+        def __enter__(self):
+            return self._fh
+
+        def __exit__(self, exc_type, exc, tb):
+            self._fh.close()
+            return False
+
+    portalocker_stub.Lock = _Lock
+    portalocker_stub.LOCK_EX = 1
+    portalocker_stub.LOCK_SH = 2
+    sys.modules["portalocker"] = portalocker_stub
+
+
+_ensure_portalocker_stub()
+sys.modules.pop("olah.proxy.files", None)
+proxy_files = importlib.import_module("olah.proxy.files")
+server_api_routes = importlib.import_module("olah.server_api_routes")
+
+
+def _fake_app(tmp_path=None, offline=False):
+    config = SimpleNamespace(
+        offline=offline,
+        hf_netloc="huggingface.co",
+        hf_lfs_netloc="cdn-lfs.huggingface.co",
+        repos_path=str(tmp_path / "repos") if tmp_path is not None else "/tmp/olah-tests",
+        hf_url_base=lambda: "https://huggingface.co",
+        hf_lfs_url_base=lambda: "https://cdn-lfs.huggingface.co",
+    )
+    return SimpleNamespace(state=SimpleNamespace(app_settings=SimpleNamespace(config=config)))
+
+
+def _make_request(method="GET", headers=None, path="/api/test", app=None):
+    raw_headers = []
+    for key, value in (headers or {}).items():
+        raw_headers.append((key.lower().encode("ascii"), value.encode("ascii")))
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "headers": raw_headers,
+        "client": ("127.0.0.1", 12345),
+        "server": ("127.0.0.1", 18090),
+        "app": app,
+    }
+    return Request(scope)
+
+
+def _patch_async_client(monkeypatch, module, response=None, raises=None, captured=None):
+    """Replace `module.httpx.AsyncClient` with a stub returning `response` (or raising)."""
+
+    class _FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def request(self, *args, **kwargs):
+            if captured is not None:
+                captured.append(kwargs)
+            if raises is not None:
+                raise raises
+            return response
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", _FakeAsyncClient)
+
+
+# ---------------------------------------------------------------------------
+# _remote_file_metadata
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_remote_file_metadata_captures_xet_headers(monkeypatch):
+    fake_response = SimpleNamespace(
+        status_code=302,
+        headers={
+            "x-xet-hash": "abc123",
+            "x-linked-size": "53121272560",
+            "x-linked-etag": '"deadbeef"',
+            "link": '<https://huggingface.co/api/models/x/y/xet-read-token/main>; rel="xet-auth"',
+        },
+    )
+    _patch_async_client(monkeypatch, proxy_files, response=fake_response)
+
+    metadata = await proxy_files._remote_file_metadata(
+        app=_fake_app(),
+        hf_url="https://huggingface.co/x/y/resolve/main/big.bin",
+        authorization=None,
+        offline=False,
+    )
+
+    assert metadata is not None
+    assert metadata.file_size == 53121272560  # falls back to x-linked-size
+    assert metadata.etag == '"deadbeef"'  # falls back to x-linked-etag
+    assert metadata.xet_headers is not None
+    assert metadata.xet_headers["x-xet-hash"] == "abc123"
+    assert "link" in metadata.xet_headers
+
+
+@pytest.mark.asyncio
+async def test_remote_file_metadata_no_xet_headers_for_plain_files(monkeypatch):
+    fake_response = SimpleNamespace(
+        status_code=200,
+        headers={"content-length": "42", "etag": '"plain-etag"'},
+    )
+    _patch_async_client(monkeypatch, proxy_files, response=fake_response)
+
+    metadata = await proxy_files._remote_file_metadata(
+        app=_fake_app(),
+        hf_url="https://huggingface.co/x/y/resolve/main/small.txt",
+        authorization=None,
+        offline=False,
+    )
+
+    assert metadata is not None
+    assert metadata.file_size == 42
+    assert metadata.etag == '"plain-etag"'
+    assert metadata.xet_headers is None
+
+
+# ---------------------------------------------------------------------------
+# _detect_xet_passthrough
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_detect_xet_passthrough_returns_none_when_no_xet_hash(monkeypatch):
+    fake_response = SimpleNamespace(
+        status_code=302,
+        headers={"location": "https://cdn-lfs.huggingface.co/.../small.bin", "content-length": "100"},
+    )
+    _patch_async_client(monkeypatch, proxy_files, response=fake_response)
+
+    result = await proxy_files._detect_xet_passthrough(
+        hf_url="https://huggingface.co/x/y/resolve/main/small.bin",
+        authorization=None,
+        commit="main",
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_detect_xet_passthrough_returns_none_on_http_error(monkeypatch):
+    _patch_async_client(monkeypatch, proxy_files, raises=httpx.ConnectError("refused"))
+
+    result = await proxy_files._detect_xet_passthrough(
+        hf_url="http://localhost:1/file",
+        authorization=None,
+        commit=None,
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_detect_xet_passthrough_mirrors_upstream_xet_headers(monkeypatch):
+    captured = []
+    fake_response = SimpleNamespace(
+        status_code=302,
+        headers={
+            "x-xet-hash": "bdcc...0f6d",
+            "x-linked-size": "53121272560",
+            "x-linked-etag": '"caa3..."',
+            "etag": '"caa3..."',
+            "link": '<https://huggingface.co/api/models/x/y/xet-read-token/abc>; rel="xet-auth"',
+            "x-repo-commit": "abc123",
+            "location": "https://cas-bridge.xethub.hf.co/xet-bridge-us/abc?signed=1",
+        },
+    )
+    _patch_async_client(monkeypatch, proxy_files, response=fake_response, captured=captured)
+
+    result = await proxy_files._detect_xet_passthrough(
+        hf_url="https://huggingface.co/x/y/resolve/abc/big.bin",
+        authorization="Bearer token",
+        commit=None,
+    )
+
+    assert result is not None
+    assert result.status_code == 302
+    headers = result.headers
+    assert headers["x-xet-hash"] == "bdcc...0f6d"
+    assert headers["x-linked-size"] == "53121272560"
+    assert headers["x-linked-etag"] == '"caa3..."'
+    assert "link" in headers
+    assert headers["accept-ranges"] == "bytes"
+    # Location must be forwarded so huggingface_hub's relative-redirect follower
+    # doesn't KeyError on the 3xx response.
+    assert headers["location"].startswith("https://cas-bridge.xethub.hf.co/")
+    # We must NOT synthesize content-length from x-linked-size: the response
+    # body is empty and x-linked-size is the *target file* size, not the body.
+    # Lying about it would mislead any client that follows the 302.
+    assert "content-length" not in headers
+    # Authorization must be forwarded upstream.
+    assert captured[0]["headers"].get("authorization") == "Bearer token"
+    assert captured[0]["follow_redirects"] is False
+    # Body is empty — the client uses headers to switch to the Xet protocol.
+    body_chunks = [chunk async for chunk in result.body]
+    assert body_chunks == [b""]
+
+
+@pytest.mark.asyncio
+async def test_detect_xet_passthrough_uses_explicit_commit_over_upstream(monkeypatch):
+    fake_response = SimpleNamespace(
+        status_code=302,
+        headers={"x-xet-hash": "h", "x-repo-commit": "upstream-commit"},
+    )
+    _patch_async_client(monkeypatch, proxy_files, response=fake_response)
+
+    result = await proxy_files._detect_xet_passthrough(
+        hf_url="https://huggingface.co/x/y/resolve/main/file",
+        authorization=None,
+        commit="explicit-commit",
+    )
+    assert result is not None
+    # When the caller passes a commit, it should win over the upstream value.
+    assert result.headers["x-repo-commit"] == "explicit-commit"
+
+
+# ---------------------------------------------------------------------------
+# _file_realtime_stream short-circuit on Xet
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_file_realtime_stream_short_circuits_on_xet(monkeypatch, tmp_path):
+    pathsinfo_called = []
+
+    async def fake_pathsinfo_generator(*args, **kwargs):
+        pathsinfo_called.append(True)
+        raise AssertionError("pathsinfo_generator must not run for Xet files")
+
+    monkeypatch.setattr(proxy_files, "pathsinfo_generator", fake_pathsinfo_generator)
+
+    sentinel = proxy_files.ProxyResult(
+        status_code=302,
+        headers={"x-xet-hash": "h"},
+        body=proxy_files.single_chunk_body(b""),
+    )
+
+    async def fake_detect(hf_url, authorization, commit):
+        return sentinel
+
+    monkeypatch.setattr(proxy_files, "_detect_xet_passthrough", fake_detect)
+
+    result = await proxy_files._file_realtime_stream(
+        app=_fake_app(tmp_path=tmp_path, offline=False),
+        repo_type="models",
+        org="x",
+        repo="y",
+        file_path="big.bin",
+        save_path=str(tmp_path / "save"),
+        head_path=str(tmp_path / "head"),
+        url="https://huggingface.co/x/y/resolve/main/big.bin",
+        request=_make_request(),
+        method="GET",
+        allow_cache=True,
+        commit="main",
+    )
+
+    assert result is sentinel
+    assert pathsinfo_called == []
+
+
+@pytest.mark.asyncio
+async def test_file_realtime_stream_skips_xet_probe_when_offline(monkeypatch, tmp_path):
+    detect_called = []
+
+    async def fake_detect(*args, **kwargs):
+        detect_called.append(True)
+        return None
+
+    monkeypatch.setattr(proxy_files, "_detect_xet_passthrough", fake_detect)
+
+    async def fake_pathsinfo_generator(*args, **kwargs):
+        return proxy_files.ProxyResult(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            body=proxy_files.single_chunk_body('[{"size": 5}]'),
+        )
+
+    async def fake_etag(*args, **kwargs):
+        return '"some-etag"'
+
+    monkeypatch.setattr(proxy_files, "pathsinfo_generator", fake_pathsinfo_generator)
+    monkeypatch.setattr(proxy_files, "_resource_etag", fake_etag)
+
+    # Offline mode should bypass the upstream xet probe entirely.
+    await proxy_files._file_realtime_stream(
+        app=_fake_app(tmp_path=tmp_path, offline=True),
+        repo_type="models",
+        org="x",
+        repo="y",
+        file_path="file.txt",
+        save_path=str(tmp_path / "save"),
+        head_path=str(tmp_path / "head"),
+        url="https://huggingface.co/x/y/resolve/main/file.txt",
+        request=_make_request(method="HEAD"),
+        method="HEAD",
+        allow_cache=True,
+        commit="main",
+    )
+
+    assert detect_called == []
+
+
+# ---------------------------------------------------------------------------
+# xet-read-token route forwarder
+# ---------------------------------------------------------------------------
+
+
+def _allow_repo_access(monkeypatch):
+    """Bypass olah's repo proxy/visibility gates by stubbing them to allow."""
+    async def _ok(*args, **kwargs):
+        return None
+    monkeypatch.setattr(server_api_routes, "ensure_repo_visibility", _ok)
+
+
+@pytest.mark.asyncio
+async def test_xet_read_token_passthrough_forwards_request(monkeypatch):
+    _allow_repo_access(monkeypatch)
+    captured = []
+    fake_response = SimpleNamespace(
+        status_code=200,
+        headers={
+            "content-type": "application/json",
+            "content-length": "123",
+            "content-encoding": "gzip",
+        },
+        content=b'{"casUrl":"https://cas-bridge.xethub.hf.co","accessToken":"jwt","exp":1}',
+    )
+    _patch_async_client(monkeypatch, server_api_routes, response=fake_response, captured=captured)
+
+    app = _fake_app()
+    request = _make_request(
+        method="GET",
+        headers={"authorization": "Bearer abc", "user-agent": "huggingface_hub/x"},
+        path="/api/models/x/y/xet-read-token/abcdef",
+        app=app,
+    )
+
+    response = await server_api_routes._xet_read_token_passthrough(
+        repo_type="models",
+        org_repo="x/y",
+        commit="abcdef",
+        request=request,
+    )
+
+    assert response.status_code == 200
+    assert response.body == fake_response.content
+    # content-encoding must be stripped (we already decoded, re-sending it would
+    # mislead clients into double-decoding). FastAPI computes its own
+    # content-length from the body, so we only check the upstream "123" was not
+    # echoed verbatim.
+    response_headers_lower = {k.lower(): v for k, v in response.headers.items()}
+    assert "content-encoding" not in response_headers_lower
+    assert response_headers_lower.get("content-length") != "123"
+    assert response_headers_lower["content-length"] == str(len(fake_response.content))
+    # Upstream URL must be the official endpoint with the right path.
+    assert captured[0]["url"] == "https://huggingface.co/api/models/x/y/xet-read-token/abcdef"
+    assert captured[0]["method"] == "GET"
+    # Authorization and Host must be forwarded.
+    assert captured[0]["headers"]["authorization"] == "Bearer abc"
+    assert captured[0]["headers"]["host"] == "huggingface.co"
+
+
+@pytest.mark.asyncio
+async def test_xet_read_token_passthrough_returns_504_on_http_error(monkeypatch):
+    _allow_repo_access(monkeypatch)
+    _patch_async_client(monkeypatch, server_api_routes, raises=httpx.ConnectError("boom"))
+
+    response = await server_api_routes._xet_read_token_passthrough(
+        repo_type="datasets",
+        org_repo="x/y",
+        commit="abcdef",
+        request=_make_request(method="GET", path="/api/...", app=_fake_app()),
+    )
+
+    assert response.status_code == 504
+
+
+@pytest.mark.asyncio
+async def test_xet_read_token_passthrough_enforces_repo_access(monkeypatch):
+    # If olah's policy blocks the repo, the route must NOT forward the request
+    # upstream — otherwise olah would silently relay an authenticated token
+    # request for a repo the mirror is configured to refuse.
+    upstream_called = []
+
+    async def _deny(*args, **kwargs):
+        from fastapi.responses import JSONResponse
+        return JSONResponse({"error": "blocked"}, status_code=403)
+
+    monkeypatch.setattr(server_api_routes, "ensure_repo_visibility", _deny)
+    _patch_async_client(
+        monkeypatch,
+        server_api_routes,
+        captured=upstream_called,
+        response=SimpleNamespace(status_code=200, headers={}, content=b""),
+    )
+
+    response = await server_api_routes._xet_read_token_passthrough(
+        repo_type="models",
+        org_repo="blocked/repo",
+        commit="abcdef",
+        request=_make_request(
+            method="GET",
+            headers={"authorization": "Bearer abc"},
+            path="/api/models/blocked/repo/xet-read-token/abcdef",
+            app=_fake_app(),
+        ),
+    )
+
+    assert response.status_code == 403
+    assert upstream_called == []  # no upstream call was made
+
+
+# ---------------------------------------------------------------------------
+# Relative-redirect following in _detect_xet_passthrough
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_detect_xet_passthrough_follows_relative_redirect(monkeypatch):
+    # When upstream returns a relative 307 (e.g. canonical-name redirect),
+    # the probe must follow it to find the response that actually carries
+    # x-xet-hash. Otherwise renamed repos quietly fall back to the
+    # legacy "file too large" path.
+    visited = []
+
+    class _FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def request(self, method, url, **kwargs):
+            visited.append(url)
+            if url.endswith("/old-name/repo/resolve/main/file.bin"):
+                return SimpleNamespace(
+                    status_code=307,
+                    headers={"location": "/new-name/repo/resolve/main/file.bin"},
+                )
+            return SimpleNamespace(
+                status_code=302,
+                headers={
+                    "x-xet-hash": "abc",
+                    "location": "https://cas-bridge.xethub.hf.co/x?signed=1",
+                },
+            )
+
+    monkeypatch.setattr(proxy_files.httpx, "AsyncClient", _FakeAsyncClient)
+
+    result = await proxy_files._detect_xet_passthrough(
+        hf_url="https://huggingface.co/old-name/repo/resolve/main/file.bin",
+        authorization=None,
+        commit=None,
+    )
+
+    assert result is not None
+    assert result.headers["x-xet-hash"] == "abc"
+    assert visited == [
+        "https://huggingface.co/old-name/repo/resolve/main/file.bin",
+        "https://huggingface.co/new-name/repo/resolve/main/file.bin",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_detect_xet_passthrough_stops_at_absolute_redirect(monkeypatch):
+    # An absolute 3xx is the *Xet* redirect itself — stop there, do not follow.
+    class _FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        call_count = 0
+
+        async def request(self, method, url, **kwargs):
+            type(self).call_count += 1
+            if type(self).call_count > 1:
+                raise AssertionError("absolute redirect must not be followed")
+            return SimpleNamespace(
+                status_code=302,
+                headers={
+                    "x-xet-hash": "h",
+                    "location": "https://cas-bridge.xethub.hf.co/abs?signed=1",
+                },
+            )
+
+    monkeypatch.setattr(proxy_files.httpx, "AsyncClient", _FakeAsyncClient)
+
+    result = await proxy_files._detect_xet_passthrough(
+        hf_url="https://huggingface.co/x/y/resolve/main/big.bin",
+        authorization=None,
+        commit=None,
+    )
+    assert result is not None
+    assert result.headers["x-xet-hash"] == "h"
+
+
+@pytest.mark.asyncio
+async def test_detect_xet_passthrough_resolves_redirects_via_rfc3986(monkeypatch):
+    # A relative redirect must replace the base URL's query string, not
+    # carry it over. urlparse._replace would be wrong here; urljoin is right.
+    visited = []
+
+    class _FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def request(self, method, url, **kwargs):
+            visited.append(url)
+            if "?old=1" in url:
+                return SimpleNamespace(
+                    status_code=307,
+                    headers={"location": "/new/path"},
+                )
+            return SimpleNamespace(
+                status_code=302,
+                headers={"x-xet-hash": "h", "location": "https://cas/x"},
+            )
+
+    monkeypatch.setattr(proxy_files.httpx, "AsyncClient", _FakeAsyncClient)
+
+    result = await proxy_files._detect_xet_passthrough(
+        hf_url="https://huggingface.co/old/path?old=1",
+        authorization=None,
+        commit=None,
+    )
+
+    assert result is not None
+    assert visited == [
+        "https://huggingface.co/old/path?old=1",
+        "https://huggingface.co/new/path",  # query string dropped, not carried
+    ]
+
+
+@pytest.mark.asyncio
+async def test_detect_xet_passthrough_caps_redirect_loop(monkeypatch):
+    # A pathological infinite redirect loop must not hang the probe.
+    class _FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def request(self, method, url, **kwargs):
+            return SimpleNamespace(
+                status_code=307,
+                headers={"location": "/loop"},
+            )
+
+    monkeypatch.setattr(proxy_files.httpx, "AsyncClient", _FakeAsyncClient)
+
+    result = await proxy_files._detect_xet_passthrough(
+        hf_url="https://huggingface.co/loop",
+        authorization=None,
+        commit=None,
+    )
+    assert result is None


### PR DESCRIPTION
## Summary

HuggingFace's content-addressed Xet storage replaces git-LFS for files larger than 50 GB. Currently olah strips Xet metadata headers (`x-xet-hash`, `x-linked-size`, `Link: rel="xet-auth"`) from upstream HEAD responses, so `hf_xet` never sees a way to switch to chunked downloads and `huggingface_hub` raises `ValueError("file too large")` against its hardcoded 50 GB HTTP cap.

Closes #50.

## Approach

`_file_realtime_stream` now probes upstream with a relative-redirect-only HEAD (mirroring what `huggingface_hub`'s `_httpx_follow_relative_redirects_with_backoff` does). If `x-xet-hash` is present in the response, it short-circuits and returns a `ProxyResult` that mirrors the upstream 302 — Xet headers, `Location`, etc. Non-Xet files fall through to the existing pathsinfo/metadata branch unchanged.

A new API forwarder at `/api/<repo_type>/<org>/<repo>/xet-read-token/<commit>` (plus the compact `/<org_repo>/` form) proxies the Xet auth-token request. This is needed because `huggingface_hub` rewrites the `huggingface.co` host in the `Link: rel="xet-auth"` URL to whatever `HF_ENDPOINT` is set to — so the token-refresh request lands on the mirror. The route reuses `ensure_repo_visibility` so it cannot be used to bypass the mirror's access policy.

## Limitations

- **No caching of Xet chunk data.** `hf_xet` reconstructs chunks directly from `cas-bridge.xethub.hf.co` using AWS-style signed URLs bound to the client's request. Re-signing those through olah would require a CAS proxy with full token re-issuance — a much larger change. This patch covers only the metadata flow (HEAD + token refresh), which is enough to unblock downloads.
- Every file resolve now pays one extra upstream HEAD for Xet detection. Cheap (HEAD against HF is fast) but not free.

## Test plan

- [x] 105/105 unit tests pass (15 new in `tests/test_xet_passthrough.py`, covering metadata capture, redirect following including renamed-repo canonicalization, access-policy enforcement, redirect-loop cap, and RFC 3986 URL resolution).
- [x] Live download of a 53 GB Xet file via the patched mirror succeeds — `hf_xet` reconstructs chunks directly from xethub, no `"file too large"` error.
- [x] Non-Xet files (README.md, plain LFS) flow unchanged through the original code path.