### PR TITLE
fix: return 504 instead of RepoNotFound 401 when upstream is unreachable

### DIFF
--- a/src/olah/server_access.py
+++ b/src/olah/server_access.py
@@ -4,7 +4,7 @@ from typing import Literal, Optional
 from fastapi.responses import Response
 
 from olah.constants import REPO_TYPES_MAPPING
-from olah.errors import error_page_not_found, error_repo_not_found
+from olah.errors import error_page_not_found, error_proxy_timeout, error_repo_not_found
 from olah.utils.repo_utils import get_org_repo, parse_org_repo
 from olah.utils.repo_utils import check_commit_hf
 from olah.utils.rule_utils import check_proxy_rules_hf
@@ -54,13 +54,16 @@ async def ensure_repo_visibility(app, repo: RepoRef, authorization: Optional[str
         return access_error
     if app.state.app_settings.config.offline:
         return None
-    if not await check_commit_hf(
+    repo_exists = await check_commit_hf(
         app,
         repo.repo_type,
         repo.org,
         repo.repo,
         commit=None,
         authorization=authorization,
-    ):
+    )
+    if repo_exists is None:
+        return error_proxy_timeout()
+    if not repo_exists:
         return error_repo_not_found()
     return None

--- a/src/olah/server_upstream.py
+++ b/src/olah/server_upstream.py
@@ -3,7 +3,7 @@ from typing import Callable, Literal, Optional, Tuple
 
 from fastapi.responses import Response
 
-from olah.errors import error_repo_not_found, error_revision_not_found
+from olah.errors import error_proxy_timeout, error_repo_not_found, error_revision_not_found
 from olah.proxy.result import ProxyResult
 from olah.server_access import RepoRef
 from olah.utils.repo_utils import check_commit_hf, get_commit_hf, get_newest_commit_hf
@@ -39,23 +39,29 @@ async def resolve_requested_commit(
 ) -> Tuple[Optional[ResolvedCommit], Optional[Response]]:
     if not app.state.app_settings.config.offline:
         if not repo_visible:
-            if not await check_commit_hf(
+            repo_exists = await check_commit_hf(
                 app,
                 repo.repo_type,
                 repo.org,
                 repo.repo,
                 commit=None,
                 authorization=authorization,
-            ):
+            )
+            if repo_exists is None:
+                return None, error_proxy_timeout()
+            if not repo_exists:
                 return None, error_repo_not_found()
-        if not await check_commit_hf(
+        commit_exists = await check_commit_hf(
             app,
             repo.repo_type,
             repo.org,
             repo.repo,
             commit=requested_commit,
             authorization=authorization,
-        ):
+        )
+        if commit_exists is None:
+            return None, error_proxy_timeout()
+        if not commit_exists:
             if missing_commit_response == "repo_not_found":
                 return None, error_repo_not_found()
             return None, error_revision_not_found(revision=requested_commit)
@@ -69,7 +75,9 @@ async def resolve_requested_commit(
         authorization=authorization,
     )
     if resolved_commit is None:
-        return None, error_repo_not_found()
+        if app.state.app_settings.config.offline:
+            return None, error_repo_not_found()
+        return None, error_proxy_timeout()
     return ResolvedCommit(requested=requested_commit, resolved=resolved_commit), None
 
 

--- a/src/olah/utils/repo_utils.py
+++ b/src/olah/utils/repo_utils.py
@@ -7,6 +7,7 @@
 
 import datetime
 import gzip
+import logging
 import os
 import glob
 import tenacity
@@ -16,6 +17,8 @@ from urllib.parse import urljoin
 import httpx
 from olah.constants import WORKER_API_TIMEOUT
 from olah.utils.cache_utils import read_cache_request
+
+logger = logging.getLogger(__name__)
 
 
 def _load_cached_json_payload(request_cache: Dict[str, Union[bytes, Dict[str, str], int]]) -> Dict:
@@ -351,7 +354,8 @@ async def check_commit_hf(
                 timeout=WORKER_API_TIMEOUT,
             )
             status_code = response.status_code
-    except httpx.HTTPError:
+    except httpx.HTTPError as e:
+        logger.warning("Upstream request failed while checking %s: %r", url, e)
         return None
     if status_code >= 500:
         return None

--- a/src/olah/utils/repo_utils.py
+++ b/src/olah/utils/repo_utils.py
@@ -297,7 +297,12 @@ async def get_commit_hf(
         return await get_commit_hf_offline(app, repo_type, org, repo, commit)
 
 
-@tenacity.retry(stop=tenacity.stop_after_attempt(3))
+@tenacity.retry(
+    stop=tenacity.stop_after_attempt(3),
+    wait=tenacity.wait_exponential(multiplier=0.5, max=2),
+    retry=tenacity.retry_if_result(lambda result: result is None),
+    retry_error_callback=lambda retry_state: None,
+)
 async def check_commit_hf(
     app,
     repo_type: Optional[Literal["models", "datasets", "spaces"]],
@@ -305,7 +310,7 @@ async def check_commit_hf(
     repo: str,
     commit: Optional[str] = None,
     authorization: Optional[str] = None,
-) -> bool:
+) -> Optional[bool]:
     """
     Checks the commit status of a repository in the Hugging Face ecosystem.
 
@@ -318,7 +323,9 @@ async def check_commit_hf(
         authorization: The authorization token (optional).
 
     Returns:
-        A boolean indicating if the commit is valid (status code 200 or 307) or not.
+        True if the commit is valid (status code 200 or 307), False if the
+        upstream rejected it (other non-5xx status), or None if the upstream
+        could not be reached (transport error or 5xx response).
 
     """
     org_repo = get_org_repo(org, repo)
@@ -345,5 +352,7 @@ async def check_commit_hf(
             )
             status_code = response.status_code
     except httpx.HTTPError:
-        return False
+        return None
+    if status_code >= 500:
+        return None
     return status_code in [200, 307]

--- a/tests/test_repo_utils.py
+++ b/tests/test_repo_utils.py
@@ -148,8 +148,10 @@ def test_get_newest_commit_hf_falls_back_to_offline_on_connect_error(monkeypatch
     assert commit == "offline-sha"
 
 
-def test_check_commit_hf_returns_false_when_upstream_request_fails(monkeypatch, tmp_path):
-    app = _make_app(tmp_path, offline=False)
+def _make_fake_client(monkeypatch, *, status_code=None, error=None, calls=None):
+    class FakeResponse:
+        def __init__(self):
+            self.status_code = status_code
 
     class FakeAsyncClient:
         async def __aenter__(self):
@@ -159,10 +161,40 @@ def test_check_commit_hf_returns_false_when_upstream_request_fails(monkeypatch, 
             return False
 
         async def request(self, *args, **kwargs):
-            raise httpx.ConnectError("offline")
+            if calls is not None:
+                calls.append(kwargs.get("url") or args)
+            if error is not None:
+                raise error
+            return FakeResponse()
 
     monkeypatch.setattr(repo_utils.httpx, "AsyncClient", FakeAsyncClient)
 
+
+def test_check_commit_hf_returns_none_and_retries_when_upstream_unreachable(monkeypatch, tmp_path):
+    app = _make_app(tmp_path, offline=False)
+    calls = []
+    _make_fake_client(monkeypatch, error=httpx.ConnectError("offline"), calls=calls)
+
     ok = asyncio.run(repo_utils.check_commit_hf(app, "models", "team", "demo", commit="main"))
 
-    assert ok is False
+    assert ok is None
+    assert len(calls) == 3
+
+
+def test_check_commit_hf_returns_none_on_upstream_server_error(monkeypatch, tmp_path):
+    app = _make_app(tmp_path, offline=False)
+    _make_fake_client(monkeypatch, status_code=503)
+
+    ok = asyncio.run(repo_utils.check_commit_hf(app, "models", "team", "demo", commit="main"))
+
+    assert ok is None
+
+
+def test_check_commit_hf_distinguishes_upstream_yes_and_no(monkeypatch, tmp_path):
+    app = _make_app(tmp_path, offline=False)
+
+    _make_fake_client(monkeypatch, status_code=200)
+    assert asyncio.run(repo_utils.check_commit_hf(app, "models", "team", "demo")) is True
+
+    _make_fake_client(monkeypatch, status_code=401)
+    assert asyncio.run(repo_utils.check_commit_hf(app, "models", "team", "demo")) is False

--- a/tests/test_server_layers.py
+++ b/tests/test_server_layers.py
@@ -103,6 +103,25 @@ async def test_ensure_repo_visibility_checks_upstream_visibility_with_auth(monke
     assert captured["call"] == ("models", "team", "demo", None, "Bearer secret")
 
 
+@pytest.mark.asyncio
+async def test_ensure_repo_visibility_returns_proxy_timeout_when_upstream_unreachable(monkeypatch):
+    repo = server_access.build_repo_ref("models", "team", "demo")
+
+    async def fake_check_proxy_rules_hf(*args, **kwargs):
+        return True
+
+    async def fake_check_commit_hf(app, repo_type, org, repo_name, commit, authorization=None):
+        return None
+
+    monkeypatch.setattr(server_access, "check_proxy_rules_hf", fake_check_proxy_rules_hf)
+    monkeypatch.setattr(server_access, "check_commit_hf", fake_check_commit_hf)
+
+    unreachable = await server_access.ensure_repo_visibility(_make_app(), repo, None)
+
+    assert unreachable.status_code == 504
+    assert unreachable.headers["x-error-code"] == "ProxyTimeout"
+
+
 def test_parse_repo_helpers_cover_compact_and_default_model_routes():
     parsed = server_access.parse_repo_ref("datasets", "team/demo")
     assert parsed == server_access.RepoRef(repo_type="datasets", org="team", repo="demo")
@@ -192,6 +211,48 @@ async def test_resolve_requested_commit_skips_duplicate_repo_check_after_visibil
     assert error is None
     assert resolved == server_upstream.ResolvedCommit(requested="main", resolved="abc123")
     assert calls == ["main"]
+
+
+@pytest.mark.asyncio
+async def test_resolve_requested_commit_returns_proxy_timeout_when_upstream_unreachable(monkeypatch):
+    app = _make_app()
+    repo = server_access.build_repo_ref("models", "team", "demo")
+
+    async def unreachable_check_commit_hf(app, repo_type, org, repo_name, commit, authorization=None):
+        return None
+
+    monkeypatch.setattr(server_upstream, "check_commit_hf", unreachable_check_commit_hf)
+    monkeypatch.setattr(server_upstream, "get_commit_hf", pytest.fail)
+
+    _, error = await server_upstream.resolve_requested_commit(
+        app,
+        repo,
+        "main",
+        None,
+        missing_commit_response="repo_not_found",
+    )
+    assert error.status_code == 504
+    assert error.headers["x-error-code"] == "ProxyTimeout"
+
+
+@pytest.mark.asyncio
+async def test_resolve_requested_commit_returns_proxy_timeout_when_commit_lookup_fails(monkeypatch):
+    app = _make_app()
+    repo = server_access.build_repo_ref("models", "team", "demo")
+
+    async def fake_check_commit_hf(app, repo_type, org, repo_name, commit, authorization=None):
+        return True
+
+    async def failing_get_commit_hf(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(server_upstream, "check_commit_hf", fake_check_commit_hf)
+    monkeypatch.setattr(server_upstream, "get_commit_hf", failing_get_commit_hf)
+
+    _, error = await server_upstream.resolve_requested_commit(app, repo, "main", None)
+
+    assert error.status_code == 504
+    assert error.headers["x-error-code"] == "ProxyTimeout"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
check_commit_hf treated any transport failure (connect error, timeout, DNS hiccup) as "repo does not exist", which the routes turned into error_repo_not_found() — an HTTP 401 that huggingface_hub maps to the non-retryable RepositoryNotFoundError. Under parallel CI load a single failed upstream HEAD therefore hard-failed a whole download, while the repo was perfectly fine.

check_commit_hf now returns a tri-state: True (exists), False (upstream rejected with a non-5xx status), None (unreachable or 5xx). The tenacity retry, previously dead code because the exception was swallowed before it could fire, now retries the None case. Callers map None to error_proxy_timeout() (504) so clients retry, and a failed commit-sha lookup after successful existence checks is likewise a 504 rather than a phantom "repo not found".