### PR TITLE
fix(cache): harden v10 block cache for multi-worker concurrency

### DIFF
--- a/src/olah/cache/olah_cache.py
+++ b/src/olah/cache/olah_cache.py
@@ -339,6 +339,12 @@ class OlahCache(object):
 
         # Paths
         self._meta_path = os.path.join(path, "meta.bin")
+        # Sidecar advisory-lock target for the meta lifecycle (open/revalidate/
+        # wipe/create/resize). Content is NEVER read or written -- the file exists
+        # only so portalocker has a stable inode to lock. Keeping it separate from
+        # meta.bin avoids the POSIX/NFS pitfall where closing any fd on an inode
+        # releases all locks the process holds on that inode.
+        self._meta_lock_path = os.path.join(path, "meta.lock")
         self._crc_path = os.path.join(path, "chunks.crc")
         self._blocks_dir = os.path.join(path, "blocks")
         self._data_path = os.path.join(self._blocks_dir, "block_${block_index}.bin")
@@ -390,40 +396,77 @@ class OlahCache(object):
         os.makedirs(self._blocks_dir, exist_ok=True)
 
         expected_etag_bytes = OlahCacheHeader._normalize_etag(expected_etag)
+        self._ensure_meta_lock()
 
+        def _read_and_validate() -> OlahCacheHeader:
+            """Read meta.bin fresh and validate identity. Returns the header or raises.
+
+            Online revalidation: a non-None ``expected_etag`` that differs means the
+            upstream content changed. Offline callers pass ``None`` to trust the disk
+            and never destroy a cache while offline.
+            """
+            with open(self._meta_path, "rb") as f:
+                candidate = OlahCacheHeader.read(f)
+            if candidate.version != CURRENT_OLAH_CACHE_VERSION:
+                raise Exception("Cache version mismatch; recreating.")
+            if expected_etag_bytes and candidate.etag != expected_etag_bytes:
+                raise Exception("Cache etag mismatch; recreating.")
+            return candidate
+
+        # Readers-writer lifecycle lock on the sidecar meta.lock:
+        #   * LOCK_SH to read+validate -- concurrent cache-hit opens don't serialize.
+        #   * LOCK_EX to wipe+create -- mutually exclusive with readers and other
+        #     creators, so no reader ever observes a half-formed cache.
+        # The SH->release->EX window is closed by a double-checked re-read under EX.
         reused = False
-        if os.path.exists(self._meta_path):
-            try:
-                with portalocker.Lock(self._meta_path, "rb", timeout=60, flags=portalocker.LOCK_SH) as f:
-                    f.seek(0)
-                    candidate = OlahCacheHeader.read(f)
-                if candidate.version != CURRENT_OLAH_CACHE_VERSION:
-                    raise Exception("Cache version mismatch; recreating.")
-                # Online revalidation: a non-None expected_etag that differs means
-                # the upstream content changed. Offline callers pass None to trust
-                # the disk and never destroy a cache while offline.
-                if expected_etag_bytes and candidate.etag != expected_etag_bytes:
-                    raise Exception("Cache etag mismatch; recreating.")
-                self.header = candidate
-                reused = True
-            except Exception:
-                self._wipe()
-                reused = False
+        try:
+            with portalocker.Lock(self._meta_lock_path, "a+", flags=portalocker.LOCK_SH):
+                if os.path.exists(self._meta_path):
+                    try:
+                        self.header = _read_and_validate()
+                        reused = True
+                    except Exception:
+                        reused = False
+        except Exception:
+            reused = False
 
         if not reused:
-            self.header = OlahCacheHeader(
-                version=CURRENT_OLAH_CACHE_VERSION,
-                block_size=block_size,
-                file_size=file_size,
-                compression_algo=compression_algo,
-                chunk_size=chunk_size,
-                etag=expected_etag_bytes,
-            )
-            self._header_dirty = True
-            self._flush_header()
-            self._resize_crc_file()
+            with portalocker.Lock(self._meta_lock_path, "a+", flags=portalocker.LOCK_EX):
+                # Double-check under EX: another worker may have created a valid
+                # cache while we waited for the exclusive lock.
+                if os.path.exists(self._meta_path):
+                    try:
+                        self.header = _read_and_validate()
+                        reused = True
+                    except Exception:
+                        reused = False
+                if not reused:
+                    self._wipe()
+                    self.header = OlahCacheHeader(
+                        version=CURRENT_OLAH_CACHE_VERSION,
+                        block_size=block_size,
+                        file_size=file_size,
+                        compression_algo=compression_algo,
+                        chunk_size=chunk_size,
+                        etag=expected_etag_bytes,
+                    )
+                    self._header_dirty = True
+                    self._flush_header()
+                    self._resize_crc_file()
 
         self.is_open = True
+
+    def _ensure_meta_lock(self) -> None:
+        """Create the sidecar meta.lock if absent. Used only as a lock target.
+
+        ``"a+"`` creates the file when missing and never truncates an existing one,
+        so concurrent creators racing to create it are both fine (idempotent).
+        """
+        if os.path.exists(self._meta_lock_path):
+            return
+        with open(self._meta_lock_path, "a+"):
+            pass
+        self._fsync_dir(self.path)
 
     def close(self):
         if not self.is_open:
@@ -456,7 +499,13 @@ class OlahCache(object):
             self._header_dirty = False
 
     def _wipe(self):
-        """Remove meta.bin / chunks.crc / block files so the cache is recreated fresh."""
+        """Remove meta.bin / chunks.crc / block files so the cache is recreated fresh.
+
+        Never removes the sidecar ``meta.lock`` or any ``.dl.lock`` / ``.tmp``
+        files: lock files are coordination primitives held by other processes, and
+        yanking one out from under a holder breaks single-flight / lifecycle
+        mutual exclusion.
+        """
         if self.path is None:
             return
         for p in (self._meta_path, self._crc_path):
@@ -466,6 +515,8 @@ class OlahCache(object):
                 pass
         if os.path.isdir(self._blocks_dir):
             for name in os.listdir(self._blocks_dir):
+                if name.endswith(".dl.lock") or name.endswith(".tmp"):
+                    continue
                 try:
                     os.remove(os.path.join(self._blocks_dir, name))
                 except FileNotFoundError:
@@ -517,9 +568,13 @@ class OlahCache(object):
             raise Exception("This file has been closed.")
         if file_size == self._get_file_size():
             return
-        self._resize_header(file_size)
-        self._flush_header()
-        self._resize_crc_file()
+        # Serialize header mutation + crc resize against other workers so a
+        # concurrent resize cannot interleave a header write with a crc resize
+        # (which would leave chunks.crc sized for a different file_size).
+        with portalocker.Lock(self._meta_lock_path, "a+", flags=portalocker.LOCK_EX):
+            self._resize_header(file_size)
+            self._flush_header()
+            self._resize_crc_file()
 
     # --- block presence ----------------------------------------------------
 
@@ -715,7 +770,7 @@ class OlahCache(object):
         bs = self._get_block_size()
 
         def read_and_verify() -> bytes:
-            with portalocker.Lock(block_path, "rb", timeout=60, flags=portalocker.LOCK_SH) as fh:
+            with portalocker.Lock(block_path, "rb", flags=portalocker.LOCK_SH) as fh:
                 if algo == 0:
                     payload = fh.read(real_len)
                 else:
@@ -791,7 +846,6 @@ class OlahCache(object):
             return
 
         bs = self._get_block_size()
-        algo = self.header.compression_algo
         start_block = start_pos // bs
         end_block = (end_pos - 1) // bs
 
@@ -799,7 +853,7 @@ class OlahCache(object):
             if not self.has_block(cur_block):
                 raise Exception("Unknown exception: read block which has not been cached.")
             try:
-                async for piece in self._stream_block_range(cur_block, start_pos, end_pos, algo):
+                async for piece in self._stream_block_range(cur_block, start_pos, end_pos):
                     if piece:
                         yield piece
             except CacheIntegrityError:
@@ -807,40 +861,64 @@ class OlahCache(object):
                 raise
 
     async def _stream_block_range(
-        self, block_index: int, range_start: int, range_end: int, algo: int
+        self, block_index: int, range_start: int, range_end: int
     ) -> AsyncIterator[bytes]:
         bs = self._get_block_size()
         block_start = block_index * bs
         block_end = min((block_index + 1) * bs, self._get_file_size())
-        real_len = block_end - block_start
         need_start = max(range_start, block_start)
         need_end = min(range_end, block_end)
+
+        # All blocking work for this block -- the shared block-file lock, the
+        # chunks.crc read, and the chunk reads + CRC verification -- runs in ONE
+        # threadpool hop so nothing blocks the event loop. Returns the verified
+        # bytes for [need_start, need_end) or raises CacheIntegrityError.
+        verified = await fastapi.concurrency.run_in_threadpool(
+            self._read_verify_block_range, block_index, need_start, need_end
+        )
+        # Yield in ~chunk_size pieces (pure memory slicing, no IO) to keep network
+        # writes bounded.
+        cs = self._get_chunk_size()
+        for off in range(0, len(verified), cs):
+            piece = verified[off:off + cs]
+            if piece:
+                yield piece
+
+    def _read_verify_block_range(
+        self, block_index: int, need_start: int, need_end: int
+    ) -> bytes:
+        """Read + CRC-verify the slice [need_start, need_end) of one block.
+
+        ``need_start``/``need_end`` are absolute file offsets already clamped to
+        this block. Raises ``CacheIntegrityError`` on any short read or CRC
+        mismatch. Synchronous by design -- called via ``run_in_threadpool``.
+        """
+        bs = self._get_block_size()
+        algo = self._get_compression_algo()
+        block_start = block_index * bs
+        block_end = min((block_index + 1) * bs, self._get_file_size())
+        real_len = block_end - block_start
         block_path = self.get_block_path(block_index)
 
         expected_crcs = self._read_chunk_crcs(block_index)
         if expected_crcs is None:
             raise CacheIntegrityError(f"Missing chunk CRCs for block {block_index}.")
 
-        with portalocker.Lock(block_path, "rb", timeout=60, flags=portalocker.LOCK_SH) as fh:
+        out = bytearray()
+        with portalocker.Lock(block_path, "rb", flags=portalocker.LOCK_SH) as fh:
             sub_lens = data_base = None
             if algo != 0:
-                sub_lens, data_base = await fastapi.concurrency.run_in_threadpool(
-                    self._read_compressed_index, fh
-                )
+                sub_lens, data_base = self._read_compressed_index(fh)
             for chunk_idx, (coff, clen) in enumerate(self._iter_chunk_spans(block_index, real_len)):
                 gstart = block_start + coff
                 gend = gstart + clen
                 if gend <= need_start or gstart >= need_end:
                     continue
                 if algo == 0:
-                    data = await fastapi.concurrency.run_in_threadpool(
-                        self._read_uncompressed, fh, coff, clen
-                    )
+                    data = self._read_uncompressed(fh, coff, clen)
                 else:
                     off = data_base + sum(sub_lens[:chunk_idx])
-                    data = await fastapi.concurrency.run_in_threadpool(
-                        self._read_compressed_sub, fh, off, sub_lens[chunk_idx], algo
-                    )
+                    data = self._read_compressed_sub(fh, off, sub_lens[chunk_idx], algo)
                 if len(data) != clen:
                     raise CacheIntegrityError(
                         f"Short read in block {block_index} chunk {chunk_idx}."
@@ -853,7 +931,8 @@ class OlahCache(object):
                 hi = min(need_end, gend) - gstart
                 piece = data[lo:hi]
                 if piece:
-                    yield piece
+                    out += piece
+        return bytes(out)
 
     @staticmethod
     def _read_uncompressed(fh: BinaryIO, off: int, clen: int) -> bytes:

--- a/src/olah/proxy/files.py
+++ b/src/olah/proxy/files.py
@@ -9,11 +9,13 @@ import asyncio
 import hashlib
 import json
 import os
+import time
 from dataclasses import dataclass
 from typing import AsyncIterator, Dict, List, Literal, Optional, Tuple
 from fastapi import Request
 import fastapi.concurrency
 import httpx
+import portalocker
 from urllib.parse import urlparse, urljoin
 
 from olah.constants import (
@@ -214,6 +216,181 @@ async def _get_file_range_from_remote(
         )
 
 
+# ---------------------------------------------------------------------------
+# Per-block single-flight download coordination
+# ---------------------------------------------------------------------------
+# Concurrent requests (across coroutines AND across uvicorn worker processes)
+# for the same uncached block share ONE upstream download. The leader wins a
+# non-blocking exclusive advisory lock on a per-block sidecar (``<block>.dl.lock``)
+# and publishes the block; followers wait for that lock, then serve from cache.
+# If the leader dies before publishing, the OS releases its lock and a follower
+# becomes the new leader (bounded retry).
+
+def _try_lock_ex(path: str):
+    """Acquire a non-blocking exclusive advisory lock on ``path``.
+
+    Returns the open file handle (caller passes it to ``_release_lock``), or
+    ``None`` if another process currently holds the lock. The lock file is
+    created on demand and used ONLY as a lock target.
+    """
+    fh = open(path, "a+")
+    try:
+        portalocker.lock(fh, portalocker.LOCK_EX | portalocker.LOCK_NB)
+        return fh
+    except portalocker.LockException:
+        fh.close()
+        return None
+
+
+def _release_lock(fh) -> None:
+    """Release an advisory lock acquired via ``_try_lock_ex``."""
+    try:
+        portalocker.unlock(fh)
+    except Exception:
+        pass
+    finally:
+        try:
+            fh.close()
+        except Exception:
+            pass
+
+
+def _wait_lock_sh(path: str, timeout: float) -> bool:
+    """Poll for a shared advisory lock (up to ``timeout`` seconds).
+
+    Returns ``True`` once the leader's exclusive lock is released (acquire +
+    immediately release), or ``False`` on timeout. Uses non-blocking probes so it
+    works uniformly across portalocker versions; the sleeps run inside a
+    threadpool so the event loop is never blocked.
+    """
+    deadline = time.time() + timeout
+    while True:
+        fh = open(path, "a+")
+        try:
+            portalocker.lock(fh, portalocker.LOCK_SH | portalocker.LOCK_NB)
+            _release_lock(fh)
+            return True
+        except portalocker.LockException:
+            fh.close()
+            if time.time() >= deadline:
+                return False
+            time.sleep(0.05)
+
+
+async def _download_full_block(
+    client: httpx.AsyncClient,
+    remote_info: RemoteInfo,
+    cache_file: OlahCache,
+    block_start: int,
+    block_end: int,
+) -> bytes:
+    """Download exactly ``[block_start, block_end)`` from upstream.
+
+    Thin collector over ``_get_file_range_from_remote`` (which already verifies
+    the received byte count). Returns the real (unpadded) block bytes.
+    """
+    out = bytearray()
+    async for chunk in _get_file_range_from_remote(
+        client, remote_info, cache_file, block_start, block_end
+    ):
+        if chunk:
+            out += chunk
+    return bytes(out)
+
+
+async def _read_block_real_payload(
+    cache_file: OlahCache, block_index: int, real_len: int
+) -> bytes:
+    """Read a cached block and return its first ``real_len`` (unpadded) bytes.
+
+    ``read_block`` verifies chunk CRCs but does NOT auto-invalidate on failure
+    (unlike ``stream_range``), so on ``CacheIntegrityError`` the block is dropped
+    here and the caller treats it as a miss.
+    """
+    try:
+        padded = await cache_file.read_block(block_index)
+    except CacheIntegrityError:
+        await cache_file._invalidate_block(block_index)
+        raise
+    return padded[:real_len]
+
+
+async def _fetch_block_single_flight(
+    *,
+    client: httpx.AsyncClient,
+    remote_info: RemoteInfo,
+    cache_file: OlahCache,
+    block_index: int,
+    block_start: int,
+    block_end: int,
+    allow_cache: bool,
+) -> bytes:
+    """Return the real (unpadded) payload of ``block_index``, single-flighted.
+
+    * Cached + CRC-valid -> serve from cache.
+    * Caching disabled -> download the range with no coordination.
+    * Otherwise coordinate via a per-block cross-process advisory lock: the
+      leader downloads + publishes (under ``asyncio.shield`` so a client
+      disconnect still lands the block); followers wait, then serve from cache.
+      A leader that dies before publishing is retried by a follower (bounded).
+    """
+    bs = cache_file._get_block_size()
+    real_len = block_end - block_start
+
+    # Fast path: serve from cache. A corrupt block is invalidated and re-fetched.
+    if cache_file.has_block(block_index):
+        try:
+            return await _read_block_real_payload(cache_file, block_index, real_len)
+        except CacheIntegrityError:
+            pass
+
+    if not allow_cache:
+        return await _download_full_block(
+            client, remote_info, cache_file, block_start, block_end
+        )
+
+    dl_lock_path = cache_file.get_block_path(block_index) + ".dl.lock"
+    max_attempts = 3
+    for _ in range(max_attempts):
+        # Try to BECOME the leader (non-blocking exclusive lock), off the event loop.
+        lock_fh = await fastapi.concurrency.run_in_threadpool(_try_lock_ex, dl_lock_path)
+        if lock_fh is not None:
+            try:
+                # Double-check under EX: a prior leader may have just published.
+                if cache_file.has_block(block_index):
+                    try:
+                        return await _read_block_real_payload(
+                            cache_file, block_index, real_len
+                        )
+                    except CacheIntegrityError:
+                        pass  # corrupt -> re-download below
+                raw_real = await _download_full_block(
+                    client, remote_info, cache_file, block_start, block_end
+                )
+                # write_block requires a full block_size buffer; pad the final block.
+                raw_block = (
+                    raw_real if real_len == bs else raw_real + b"\x00" * (bs - real_len)
+                )
+                # _write_block_safely shields the publish so a leader disconnect
+                # still lands the block (followers depend on it).
+                await _write_block_safely(cache_file, block_index, raw_block, allow_cache=True)
+                return raw_real
+            finally:
+                _release_lock(lock_fh)
+        # Someone else is the leader: wait for it to finish, then serve from cache.
+        await fastapi.concurrency.run_in_threadpool(_wait_lock_sh, dl_lock_path, 120)
+        if cache_file.has_block(block_index):
+            try:
+                return await _read_block_real_payload(cache_file, block_index, real_len)
+            except CacheIntegrityError:
+                pass  # corrupt or leader died mid-publish -> retry as leader
+        # Block still absent -> leader died before publishing. Loop and try to
+        # become the new leader.
+    raise Exception(
+        f"block {block_index} never became available after {max_attempts} single-flight attempts"
+    )
+
+
 async def _file_chunk_get(
     app,
     save_path: str,
@@ -235,7 +412,10 @@ async def _file_chunk_get(
     # from the stored one wipes & recreates the cache. Offline callers pass None
     # to trust the disk. The constructor handles create / reuse / wipe uniformly
     # and sizes chunks.crc for new caches.
-    cache_file = OlahCache(
+    # Opening a cache does mkdirs + advisory locking + (on create) fsync, all of
+    # which would block the event loop -- run it in the threadpool.
+    cache_file = await fastapi.concurrency.run_in_threadpool(
+        OlahCache,
         save_path,
         file_size=file_size,
         block_size=block_size,
@@ -243,7 +423,7 @@ async def _file_chunk_get(
         compression_algo=compression_algo,
         expected_etag=expected_etag,
     )
-    
+
     # Refresh access time
     touch_file_access_time(save_path)
     try:
@@ -255,8 +435,10 @@ async def _file_chunk_get(
             for (range_start_pos, range_end_pos), is_remote in ranges_and_cache_list:
                 # range_start_pos is zero-index and range_end_pos is exclusive
                 if is_remote:
-                    # Cache miss: stream from upstream, reassemble chunks into full
-                    # blocks, and persist them to the cache as they complete.
+                    # Cache miss: fetch each missing block individually under a
+                    # per-block single-flight lock so concurrent requests for the
+                    # same uncached block share ONE upstream download (the leader
+                    # downloads + publishes; followers wait then serve from cache).
                     if url is None:
                         # Cache-only mode (e.g. the Xet route serving a fully-cached
                         # object without re-resolving HF). A miss here means a block
@@ -265,69 +447,31 @@ async def _file_chunk_get(
                         raise Exception(
                             "cache miss in cache-only mode (no upstream URL available)"
                         )
-                    generator = _get_file_range_from_remote(
-                        client,
-                        RemoteInfo(method, url, headers),
-                        cache_file,
-                        range_start_pos,
-                        range_end_pos,
-                    )
-                    cur_pos = range_start_pos
-                    stream_cache = bytearray()
-                    last_block, last_block_start_pos, last_block_end_pos = get_block_info(
-                        cur_pos, cache_file._get_block_size(), cache_file._get_file_size()
-                    )
-                    cur_block = last_block
-                    try:
-                        async for chunk in generator:
-                            if len(chunk) != 0:
-                                yield bytes(chunk)
-                                stream_cache += chunk
-                                cur_pos += len(chunk)
-
-                            cur_block = cur_pos // cache_file._get_block_size()
-
-                            if cur_block == last_block:
-                                continue
-                            split_pos = last_block_end_pos - max(
-                                last_block_start_pos, range_start_pos
-                            )
-                            raw_block = stream_cache[:split_pos]
-                            stream_cache = stream_cache[split_pos:]
-                            if len(raw_block) == cache_file._get_block_size():
-                                await _write_block_safely(
-                                    cache_file,
-                                    last_block,
-                                    raw_block,
-                                    allow_cache,
-                                )
-                            last_block, last_block_start_pos, last_block_end_pos = get_block_info(
-                                cur_pos, cache_file._get_block_size(), cache_file._get_file_size()
-                            )
-                    finally:
-                        raw_block = bytes(stream_cache)
-                        if cur_pos == range_end_pos:
-                            final_block = last_block
-                            final_start = last_block_start_pos
-                            final_end = last_block_end_pos
-                            if final_start >= range_start_pos:
-                                expected_len = final_end - final_start
-                                if len(raw_block) == expected_len:
-                                    if expected_len < cache_file._get_block_size():
-                                        raw_block += b"\x00" * (
-                                            cache_file._get_block_size() - expected_len
-                                        )
-                                    await _write_block_safely(
-                                        cache_file,
-                                        final_block,
-                                        raw_block,
-                                        allow_cache,
-                                    )
-
-                    if cur_pos != range_end_pos:
-                        raise Exception(
-                            f"The size of remote range ({range_end_pos - range_start_pos}) is different from sent size ({cur_pos - range_start_pos})."
+                    bs = cache_file._get_block_size()
+                    fs = cache_file._get_file_size()
+                    remote_info = RemoteInfo(method, url, headers)
+                    first_block = range_start_pos // bs
+                    last_block = (range_end_pos - 1) // bs
+                    for blk in range(first_block, last_block + 1):
+                        block_start = blk * bs
+                        block_end = min((blk + 1) * bs, fs)
+                        block_bytes = await _fetch_block_single_flight(
+                            client=client,
+                            remote_info=remote_info,
+                            cache_file=cache_file,
+                            block_index=blk,
+                            block_start=block_start,
+                            block_end=block_end,
+                            allow_cache=allow_cache,
                         )
+                        # Yield only the slice of the block the client asked for
+                        # (a range strictly inside one block still fetches the
+                        # whole block, since caching is block-granular).
+                        lo = max(range_start_pos, block_start) - block_start
+                        hi = min(range_end_pos, block_end) - block_start
+                        piece = block_bytes[lo:hi]
+                        if piece:
+                            yield piece
                 else:
                     # Cache hit: blocks are already on disk -- no reassembly, no
                     # cache writes. OlahCache.stream_range serves both uncompressed
@@ -351,7 +495,7 @@ async def _file_chunk_get(
                             f"The size of cached range ({range_end_pos - range_start_pos}) is different from sent size ({cur_pos - range_start_pos})."
                         )
     finally:
-        cache_file.close()
+        await fastapi.concurrency.run_in_threadpool(cache_file.close)
 
 
 async def _stream_single_range(

--- a/src/olah/proxy/xet.py
+++ b/src/olah/proxy/xet.py
@@ -19,6 +19,7 @@ import os
 from typing import Optional, Tuple
 
 import httpx
+import fastapi.concurrency
 from fastapi import FastAPI, Request
 
 from olah.cache.olah_cache import OlahCache
@@ -136,11 +137,15 @@ async def xet_get_generator(
     # resolve HEAD on every request. Only re-resolve a fresh signed URL when a
     # block is actually missing.
     if size and os.path.exists(os.path.join(save_path, "meta.bin")):
-        peek = OlahCache(save_path, file_size=size, expected_etag=xet_hash)
-        try:
-            fully_cached = peek.is_fully_cached()
-        finally:
-            peek.close()
+        # Opening the cache + stat-ing every block is sync IO; run it off the loop.
+        def _peek_fully_cached() -> bool:
+            peek = OlahCache(save_path, file_size=size, expected_etag=xet_hash)
+            try:
+                return peek.is_fully_cached()
+            finally:
+                peek.close()
+
+        fully_cached = await fastapi.concurrency.run_in_threadpool(_peek_fully_cached)
         if fully_cached:
             return await _build_file_response(
                 app=app,

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,0 +1,306 @@
+# coding=utf-8
+# Copyright 2024 XiaHan
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+"""Concurrency tests for the v10 block cache.
+
+These exercise the four cross-process / cross-coroutine hardening fixes:
+
+1. ``meta.lock`` readers-writer lifecycle -- concurrent opens of a stale cache
+   produce exactly ONE create.
+2. Per-block single-flight -- N concurrent requests for the same uncached file
+   download each block exactly once.
+3. Leader-death recovery -- a leader that fails mid-download is retried by a
+   follower.
+4. ``resize`` under the exclusive meta lock -- concurrent resizes never leave a
+   torn header / crc-file combo.
+
+They require a REAL ``portalocker`` (the codebase uses ``fcntl.flock``, which
+excludes across both threads and processes), so the module is skipped when
+portalocker is absent.
+"""
+
+import asyncio
+import os
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("portalocker")
+
+from olah.cache.olah_cache import (  # noqa: E402
+    CURRENT_OLAH_CACHE_VERSION,
+    OlahCache,
+    OlahCacheHeader,
+)
+from olah.proxy import files as proxy_files  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _make_app(tmp_path, block_size=None, chunk_size=None):
+    config = SimpleNamespace(
+        offline=False,
+        hf_netloc="huggingface.co",
+        hf_lfs_netloc="cdn-lfs.huggingface.co",
+        repos_path=str(tmp_path / "repos"),
+        hf_url_base=lambda: "https://huggingface.co",
+        hf_lfs_url_base=lambda: "https://cdn-lfs.huggingface.co",
+        cache_compression="none",
+        cache_block_size=block_size,
+        cache_chunk_size=chunk_size,
+    )
+    return SimpleNamespace(
+        state=SimpleNamespace(app_settings=SimpleNamespace(config=config))
+    )
+
+
+class _FakeStreamResponse:
+    """Mimics the slice of httpx's streaming response that the downloader reads."""
+
+    def __init__(self, body: bytes, status_code: int = 206):
+        self.status_code = status_code
+        self.headers = {"content-length": str(len(body))}
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def aiter_raw(self):
+        if not self._body:
+            return
+        mid = max(1, len(self._body) // 2)
+        yield self._body[:mid]
+        yield self._body[mid:]
+
+
+class _RangeSliceClient:
+    """Counts upstream ``stream()`` calls and serves the requested byte range.
+
+    Range-aware so it stays correct under per-block fetching (each block is a
+    separate ``bytes=`` range request). Optional ``fail_first_n`` simulates a
+    leader that dies before publishing its first ``fail_first_n`` downloads.
+    """
+
+    def __init__(self, payload: bytes, fail_first_n: int = 0):
+        self.payload = payload
+        self.calls = 0
+        self._fail_first_n = fail_first_n
+        self._lock = threading.Lock()
+
+    def stream(self, **kwargs):
+        headers = kwargs.get("headers") or {}
+        rng = headers.get("range", "")
+        if rng.startswith("bytes="):
+            s, _, e = rng[6:].partition("-")
+            body = self.payload[int(s): int(e) + 1 if e else len(self.payload)]
+        else:
+            body = self.payload
+        with self._lock:
+            self.calls += 1
+            call_n = self.calls
+        if call_n <= self._fail_first_n:
+            raise RuntimeError("simulated leader death before publish")
+        return _FakeStreamResponse(body)
+
+
+async def _collect(gen):
+    return b"".join([c async for c in gen])
+
+
+# ---------------------------------------------------------------------------
+# 1. meta.lock serializes creation
+# ---------------------------------------------------------------------------
+
+def test_concurrent_open_serializes_cache_creation(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    # Seed a corrupt meta.bin so every open must wipe + create.
+    (cache_dir / "meta.bin").write_bytes(b"NOT_AN_OLAH_CACHE_HEADER")
+
+    flush_count = {"n": 0}
+    count_lock = threading.Lock()
+    orig_flush = OlahCache._flush_header
+
+    def counting_flush(self):
+        with count_lock:
+            flush_count["n"] += 1
+        return orig_flush(self)
+
+    errors = []
+
+    def worker():
+        try:
+            c = OlahCache(
+                str(cache_dir),
+                file_size=1024,
+                block_size=64,
+                chunk_size=64,
+                expected_etag="abc",
+            )
+            c.close()
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    OlahCache._flush_header = counting_flush
+    try:
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        OlahCache._flush_header = orig_flush
+
+    assert not errors
+    # Despite 8 concurrent opens on a corrupt cache, exactly one create ran.
+    assert flush_count["n"] == 1, f"expected 1 create, got {flush_count['n']}"
+    # And the resulting cache is valid and reusable.
+    c = OlahCache(str(cache_dir), expected_etag="abc")
+    try:
+        assert c.header.version == CURRENT_OLAH_CACHE_VERSION
+        assert c.header.etag == b"abc"
+    finally:
+        c.close()
+
+
+# ---------------------------------------------------------------------------
+# 2. per-block single-flight dedups concurrent downloads
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_single_flight_dedups_concurrent_block_downloads(tmp_path):
+    block_size = 64
+    payload = bytes((i * 13) % 256 for i in range(150))  # 3 blocks, last partial
+    num_blocks = (len(payload) + block_size - 1) // block_size
+    save_path = tmp_path / "cache"
+
+    client = _RangeSliceClient(payload)
+    app = _make_app(tmp_path, block_size=block_size, chunk_size=block_size)
+
+    async def fetch():
+        return await _collect(
+            proxy_files._file_chunk_get(
+                app=app,
+                save_path=str(save_path),
+                head_path=str(tmp_path / "head"),
+                client=client,
+                method="GET",
+                url="https://huggingface.co/team/demo/resolve/main/blob.bin",
+                headers={},
+                allow_cache=True,
+                file_size=len(payload),
+            )
+        )
+
+    n = 4
+    results = await asyncio.gather(*(fetch() for _ in range(n)))
+
+    # Every caller got the full correct file...
+    assert all(r == payload for r in results)
+    # ...and each block was downloaded exactly once (not n * num_blocks).
+    assert client.calls == num_blocks, (
+        f"expected {num_blocks} upstream downloads (single-flight), got {client.calls}"
+    )
+    # ...and the cache is now fully populated.
+    c = OlahCache(str(save_path))
+    try:
+        assert c.is_fully_cached()
+    finally:
+        c.close()
+
+
+# ---------------------------------------------------------------------------
+# 3. leader-death recovery -- a failed leader is retried by a follower
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_single_flight_recovers_when_leader_dies(tmp_path):
+    block_size = 64
+    payload = bytes((i * 5) % 256 for i in range(70))  # 2 blocks
+    num_blocks = (len(payload) + block_size - 1) // block_size
+    save_path = tmp_path / "cache"
+
+    # The first upstream call (the first leader's download) fails; the follower
+    # that takes over succeeds.
+    client = _RangeSliceClient(payload, fail_first_n=1)
+    app = _make_app(tmp_path, block_size=block_size, chunk_size=block_size)
+
+    async def fetch():
+        return await _collect(
+            proxy_files._file_chunk_get(
+                app=app,
+                save_path=str(save_path),
+                head_path=str(tmp_path / "head"),
+                client=client,
+                method="GET",
+                url="https://huggingface.co/team/demo/resolve/main/blob.bin",
+                headers={},
+                allow_cache=True,
+                file_size=len(payload),
+            )
+        )
+
+    results = await asyncio.gather(*(fetch() for _ in range(2)), return_exceptions=True)
+
+    successes = [r for r in results if isinstance(r, bytes)]
+    failures = [r for r in results if isinstance(r, Exception)]
+    # The first leader failed; the follower took over and delivered the file.
+    assert len(successes) == 1, f"expected 1 success, got {len(successes)}: {results}"
+    assert successes[0] == payload
+    assert len(failures) == 1
+    # Upstream calls: the failed leader's block-0 attempt (1) + the successful
+    # follower downloading every block (num_blocks). No block downloaded twice
+    # by the successful path.
+    assert client.calls == num_blocks + 1, (
+        f"expected {num_blocks + 1} upstream calls, got {client.calls}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. resize under the exclusive meta lock
+# ---------------------------------------------------------------------------
+
+def test_concurrent_resize_never_tears_header(tmp_path):
+    cache_dir = tmp_path / "cache"
+    c0 = OlahCache(str(cache_dir), file_size=64, block_size=64, chunk_size=64)
+    c0.close()
+
+    sizes = [128, 192, 256, 320, 96]
+
+    def worker(size):
+        c = OlahCache(str(cache_dir), expected_etag=None)
+        try:
+            c.resize(size)
+        finally:
+            c.close()
+
+    threads = [threading.Thread(target=worker, args=(s,)) for s in sizes]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # The final file_size must be one of the requested sizes (last writer wins),
+    # never a torn value, and chunks.crc must match that size exactly.
+    c = OlahCache(str(cache_dir), expected_etag=None)
+    try:
+        fs = c.header.file_size
+        assert fs in sizes, f"torn file_size {fs} not in {sizes}"
+        chunk_number = (fs + c.header.chunk_size - 1) // c.header.chunk_size
+        crc_path = os.path.join(str(cache_dir), "chunks.crc")
+        assert os.path.getsize(crc_path) == chunk_number * 4, (
+            f"chunks.crc size {os.path.getsize(crc_path)} != {chunk_number * 4}"
+        )
+    finally:
+        c.close()

--- a/tests/test_proxy_files.py
+++ b/tests/test_proxy_files.py
@@ -35,6 +35,25 @@ def _load_proxy_files_module():
         portalocker_stub.Lock = _Lock
         portalocker_stub.LOCK_EX = 1
         portalocker_stub.LOCK_SH = 2
+        portalocker_stub.LOCK_NB = 4
+
+        # The per-block single-flight path uses the lower-level lock()/unlock()
+        # API plus LOCK_NB and LockException. The stub never contends, so a lock
+        # attempt always succeeds and never raises -- a single request is always
+        # the leader, which is all these (single-request) unit tests exercise.
+
+        class _LockException(Exception):
+            pass
+
+        def _lock(fh, flags, timeout=None):
+            return fh
+
+        def _unlock(fh):
+            return None
+
+        portalocker_stub.LockException = _LockException
+        portalocker_stub.lock = _lock
+        portalocker_stub.unlock = _unlock
         sys.modules["portalocker"] = portalocker_stub
 
     return importlib.import_module("olah.proxy.files")
@@ -719,6 +738,7 @@ async def test_file_chunk_get_persists_single_block_files(tmp_path):
     assert block_path.stat().st_size > 0
 
 
+@pytest.mark.asyncio
 async def test_file_chunk_get_streams_from_cache_without_touching_upstream(tmp_path):
     # Pre-populate a multi-block cache, then ensure _file_chunk_get serves it
     # entirely from cache (upstream never called) and yields exact bytes for both
@@ -730,7 +750,7 @@ async def test_file_chunk_get_streams_from_cache_without_touching_upstream(tmp_p
     payload = bytes((i * 7) % 256 for i in range(200))  # 4 blocks (last partial, 8 bytes)
     num_blocks = (len(payload) + block_size - 1) // block_size
 
-    cache = proxy_files.OlahCache.create(str(save_path), block_size=block_size, compression_algo=0)
+    cache = proxy_files.OlahCache.create(str(save_path), block_size=block_size, chunk_size=block_size, compression_algo=0)
     cache.resize(len(payload))
     for i in range(num_blocks):
         blk = payload[i * block_size:(i + 1) * block_size]


### PR DESCRIPTION
Fixes four concurrency defects that trigger under multi-worker / multi-client load. uvicorn `--workers N` spawns cross-process workers, and `server.py` already claims the cache dir is multi-process safe — these make that claim true.

## The four fixes

**1. `meta.lock` readers-writer lifecycle** (`olah_cache.py`)
- New sidecar `meta.lock` (used only as a `flock` target, never read/written — avoids the POSIX-lock close-drops-lock pitfall).
- `open()` takes `LOCK_SH` to read/validate (cache hits don't serialize), upgrades to `LOCK_EX` (double-checked) to wipe+create. Two workers can no longer both recreate the same cache; a reader never sees a half-formed header.
- `_wipe()` skips `*.dl.lock` / `*.tmp` so in-flight coordination locks survive a wipe.

**2. `resize()` under `LOCK_EX`** — concurrent resizes can't interleave a header write with a `chunks.crc` resize. The _file_size "create-0-then-resize" window is subsumed by the locked create path.

**3. Per-block single-flight** (`files.py`)
- Cache-miss path now fetches one block at a time under a cross-process advisory lock `blocks/<n>.bin.dl.lock`: the leader (non-blocking `LOCK_EX`) downloads + publishes; followers wait then serve from cache; a leader that dies before publishing is retried by a follower (bounded). Dedups across both coroutines and worker processes.
- Deletes the fragile `stream_cache` reassembly state machine (~50 lines).

**4. Offload all blocking IO off the event loop**
- `OlahCache(...)` construction + `close()` run via `run_in_threadpool` at the proxy boundaries (`files.py`, `xet.py`).
- `_stream_block_range` now runs the SH-lock acquire + CRC read + read/verify in a single `run_in_threadpool` hop per block (previously the lock acquire and CRC read ran on the event loop).

## Tests
- `tests/test_concurrency.py` (new, real `fcntl.flock`): concurrent-open serialization (8 threads on a corrupt cache → exactly 1 create), single-flight dedup (4 concurrent misses → each block downloaded once), leader-death recovery, concurrent resize non-tearing.
- Fixed a latent test bug: `test_file_chunk_get_streams_from_cache_without_touching_upstream` was missing `@pytest.mark.asyncio` (never ran) + underspecified cache create; now runs & passes.
- Offline suite: **117 passed** (1 pre-existing unrelated `server_layers` failure, verified failing on clean code).
- Live e2e (`OLAH_E2E_LIVE=1`, real Qwen3-4B tokenizer.json): **6 passed**.

## Notes / out of scope
- Verified `portalocker 4.1.0` uses `fcntl.flock` → exclusion holds across both threads and processes.
- Per-block fetch is sequential (one upstream range request per 64 MiB block). A bounded prefetch window can be layered on later without touching the locking model — left as future throughput work.
