### PR TITLE
perf(cache): bitmap presence map, whole-entry lock-aware eviction, atomic JSON cache

### DIFF
--- a/src/olah/cache/olah_cache.py
+++ b/src/olah/cache/olah_cache.py
@@ -35,7 +35,6 @@ Design notes
 
 import lzma
 import os
-import string
 import struct
 import threading
 import zlib
@@ -43,6 +42,8 @@ from typing import AsyncIterator, BinaryIO, Dict, List, Optional, Union
 
 import fastapi.concurrency
 import portalocker
+
+from olah.cache.bitset import Bitset
 
 CURRENT_OLAH_CACHE_VERSION = 10
 
@@ -347,7 +348,12 @@ class OlahCache(object):
         self._meta_lock_path = os.path.join(path, "meta.lock")
         self._crc_path = os.path.join(path, "chunks.crc")
         self._blocks_dir = os.path.join(path, "blocks")
-        self._data_path = os.path.join(self._blocks_dir, "block_${block_index}.bin")
+
+        # In-memory presence bitmap (revives cache/bitset.py). Built once per
+        # open() from a single blocks/ scan so bulk iterators (is_fully_cached,
+        # get_contiguous_ranges) avoid stat-ing every block. has_block() stays
+        # disk-authoritative for single-block decisions.
+        self._present: Optional[Bitset] = None
 
         self.open(
             path,
@@ -455,6 +461,8 @@ class OlahCache(object):
                     self._resize_crc_file()
 
         self.is_open = True
+        self._build_present_map()
+        self._touch_access()
 
     def _ensure_meta_lock(self) -> None:
         """Create the sidecar meta.lock if absent. Used only as a lock target.
@@ -467,6 +475,19 @@ class OlahCache(object):
         with open(self._meta_lock_path, "a+"):
             pass
         self._fsync_dir(self.path)
+
+    def _touch_access(self) -> None:
+        """Bump meta.lock mtime as a reliable last-access marker for LRU eviction.
+
+        FS atime is unreliable under noatime/relatime, and the old code touched
+        the wrong inode anyway (a directory, not the block files). mtime is always
+        maintained by the FS and meta.lock is never content-read, so its mtime is
+        an unambiguous per-entry access signal that eviction sorts on.
+        """
+        try:
+            os.utime(self._meta_lock_path, None)
+        except OSError:
+            pass
 
     def close(self):
         if not self.is_open:
@@ -508,6 +529,9 @@ class OlahCache(object):
         """
         if self.path is None:
             return
+        # The bitmap is stale once blocks/ is cleared; open() rebuilds it after
+        # recreation.
+        self._present = None
         for p in (self._meta_path, self._crc_path):
             try:
                 os.remove(p)
@@ -575,29 +599,84 @@ class OlahCache(object):
             self._resize_header(file_size)
             self._flush_header()
             self._resize_crc_file()
+        # file_size (and thus block count) changed; rebuild the presence bitmap.
+        self._build_present_map()
 
     # --- block presence ----------------------------------------------------
 
     def has_block(self, block_index: int) -> bool:
+        """Disk-authoritative presence check (exists + non-zero size).
+
+        Used for single-block decisions where cross-process correctness matters
+        (read pre-check, single-flight double-check). Bulk iterators should use
+        is_block_cached(), which consults the in-memory bitmap.
+        """
         block_path = self.get_block_path(block_index)
         return os.path.exists(block_path) and os.path.getsize(block_path) > 0
+
+    def is_block_cached(self, block_index: int) -> bool:
+        """Bitmap-backed O(1) presence check for bulk iteration.
+
+        Best-effort: reflects blocks/ at open() time plus this instance's own
+        writes/invalidations. A stale miss only ever costs a redundant
+        single-flight download (has_block still gates reads/writes), never
+        corruption. Falls back to has_block if the bitmap is unavailable.
+        """
+        if self._present is None:
+            return self.has_block(block_index)
+        try:
+            return self._present.test(block_index)
+        except IndexError:
+            return False
 
     def is_fully_cached(self) -> bool:
         """True if every block of the file is present on disk.
 
-        Used to decide whether a request can be served from the cache alone
-        (no upstream re-resolve / fetch). A zero-size file is treated as NOT
-        fully cached so callers fall through to the resolve path.
+        Uses the in-memory bitmap when available (one scandir at open, not a stat
+        per block). A zero-size file is treated as NOT fully cached so callers
+        fall through to the resolve path.
         """
         if self.header is None:
             return False
         n = self._get_block_number()
         if n == 0:
             return False
+        if self._present is not None:
+            return all(self._present.test(b) for b in range(n))
         return all(self.has_block(b) for b in range(n))
 
+    def _build_present_map(self) -> None:
+        """Populate ``self._present`` from a single blocks/ scan.
+
+        Turns the bulk-iterator hot path (is_fully_cached / get_contiguous_ranges
+        over thousands of blocks) from one stat per block into one scandir.
+        Re-called after resize, since file_size changes the block count.
+        """
+        if self.header is None:
+            self._present = None
+            return
+        n = self.header.block_number
+        bs = Bitset(n if n > 0 else 1)
+        try:
+            with os.scandir(self._blocks_dir) as it:
+                for entry in it:
+                    if not entry.is_file():
+                        continue
+                    name = entry.name
+                    if not (name.startswith("block_") and name.endswith(".bin")):
+                        continue
+                    idx_str = name[len("block_"):-len(".bin")]
+                    if not idx_str.isdigit():
+                        continue
+                    idx = int(idx_str)
+                    if 0 <= idx < n:
+                        bs.set(idx)
+        except FileNotFoundError:
+            pass
+        self._present = bs
+
     def get_block_path(self, block_index: int) -> str:
-        return string.Template(self._data_path).substitute(block_index=f"{block_index:0>8}")
+        return os.path.join(self._blocks_dir, f"block_{block_index:0>8}.bin")
 
     # --- chunks.crc --------------------------------------------------------
 
@@ -735,7 +814,14 @@ class OlahCache(object):
                     os.remove(tmp_path)
                 except OSError:
                     pass
-        # Block presence is tracked by file existence; no header field changed.
+        # Block presence is tracked by file existence; mirror it in the bitmap so
+        # bulk iterators (is_fully_cached / get_contiguous_ranges) stay in sync.
+        with self._header_lock:
+            if self._present is not None:
+                try:
+                    self._present.set(block_index)
+                except IndexError:
+                    pass
 
     @staticmethod
     def _fsync_dir(dir_path: str) -> None:
@@ -780,7 +866,19 @@ class OlahCache(object):
                 payload = payload + b"\x00" * (bs - len(payload))
             return payload
 
-        return await fastapi.concurrency.run_in_threadpool(read_and_verify)
+        try:
+            return await fastapi.concurrency.run_in_threadpool(read_and_verify)
+        except FileNotFoundError:
+            # Block was evicted between has_block() and the open. Treat as a miss
+            # (clear the stale bitmap bit) so the caller re-fetches instead of
+            # surfacing an opaque 500.
+            with self._header_lock:
+                if self._present is not None:
+                    try:
+                        self._present.clear(block_index)
+                    except IndexError:
+                        pass
+            return None
 
     def _decompress_block(self, fh: BinaryIO, algo: int, real_len: int) -> bytes:
         raw = fh.read()
@@ -829,6 +927,12 @@ class OlahCache(object):
                 os.fsync(f.fileno())
         except FileNotFoundError:
             pass
+        with self._header_lock:
+            if self._present is not None:
+                try:
+                    self._present.clear(block_index)
+                except IndexError:
+                    pass
 
     async def stream_range(self, start_pos: int, end_pos: int) -> AsyncIterator[bytes]:
         """Yield verified ~chunk-size pieces for [start_pos, end_pos).
@@ -851,7 +955,11 @@ class OlahCache(object):
 
         for cur_block in range(start_block, end_block + 1):
             if not self.has_block(cur_block):
-                raise Exception("Unknown exception: read block which has not been cached.")
+                # Block vanished (e.g. whole-entry eviction) between the coverage
+                # check and now. Drop it and surface a typed error the caller can
+                # recover from (re-fetch from upstream) instead of an opaque 500.
+                await self._invalidate_block(cur_block)
+                raise CacheIntegrityError(f"Block {cur_block} is not available.")
             try:
                 async for piece in self._stream_block_range(cur_block, start_pos, end_pos):
                     if piece:
@@ -859,6 +967,10 @@ class OlahCache(object):
             except CacheIntegrityError:
                 await self._invalidate_block(cur_block)
                 raise
+            except FileNotFoundError:
+                # Block file removed mid-read (eviction). Same recovery path.
+                await self._invalidate_block(cur_block)
+                raise CacheIntegrityError(f"Block {cur_block} vanished mid-read.")
 
     async def _stream_block_range(
         self, block_index: int, range_start: int, range_end: int

--- a/src/olah/cache/stat.py
+++ b/src/olah/cache/stat.py
@@ -5,55 +5,123 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
+"""Cache inspection tool for the v10 on-disk block cache.
+
+Run directly to print a cache entry's header + per-block presence (derived from a
+single ``blocks/`` scan, not a stat per block)::
+
+    python -m olah.cache.stat --file <path-to-cache-entry-dir>
+    python -m olah.cache.stat -f repos/files/.../resolve/main/blob.safetensors
+
+Optionally export the reassembled file when every block is present::
+
+    python -m olah.cache.stat -f <entry> --export out.bin
+"""
+
 import argparse
 import os
 import sys
+
 from olah.cache.olah_cache import OlahCache
 
-def get_size_human(size: int) -> str:
-    if size > 1024 * 1024 * 1024:
-        return f"{int(size / (1024 * 1024 * 1024)):.4f}GB"
-    elif size > 1024 * 1024:
-        return f"{int(size / (1024 * 1024)):.4f}MB"
-    elif size > 1024:
-        return f"{int(size / (1024)):.4f}KB"
-    else:
-        return f"{size:.4f}B"
 
-def insert_newlines(input_str, every=10):
-    return '\n'.join(input_str[i:i+every] for i in range(0, len(input_str), every))
+def _size_human(size: int) -> str:
+    for unit, factor in (("GB", 1024**3), ("MB", 1024**2), ("KB", 1024)):
+        if size >= factor:
+            return f"{size / factor:.4f}{unit}"
+    return f"{size:.4f}B"
+
+
+def _present_blocks(cache_dir: str, block_number: int):
+    """Return a list of bools (length block_number) from one blocks/ scan.
+
+    Falls back to ``has_block`` (per-block stat) only if the directory scan is
+    unavailable, so this stays correct even outside an open ``OlahCache``.
+    """
+    present = [False] * max(block_number, 0)
+    blocks_dir = os.path.join(cache_dir, "blocks")
+    try:
+        names = os.listdir(blocks_dir)
+    except OSError:
+        return present
+    for name in names:
+        if not (name.startswith("block_") and name.endswith(".bin")):
+            continue
+        idx_str = name[len("block_"):-len(".bin")]
+        if not idx_str.isdigit():
+            continue
+        idx = int(idx_str)
+        if 0 <= idx < block_number:
+            present[idx] = True
+    return present
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Olah v10 cache visualization tool.")
+    parser.add_argument("--file", "-f", type=str, required=True, help="Path of the Olah cache entry directory")
+    parser.add_argument("--export", "-e", type=str, default="", help="Export the cached file if all blocks are present")
+    args = parser.parse_args()
+
+    cache_dir = args.file
+    if not os.path.isdir(cache_dir):
+        print(f"Not a cache entry directory: {cache_dir}", file=sys.stderr)
+        return 1
+
+    # On-disk size of the whole entry (meta.bin + chunks.crc + blocks/*).
+    on_disk = 0
+    for root, _dirs, files in os.walk(cache_dir):
+        for name in files:
+            try:
+                on_disk += os.path.getsize(os.path.join(root, name))
+            except OSError:
+                pass
+
+    try:
+        cache = OlahCache(cache_dir)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Failed to open cache: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        h = cache.header
+        block_number = h.block_number
+        present = _present_blocks(cache_dir, block_number)
+        cached = sum(present)
+
+        print(f"File: {cache_dir}")
+        print(f"Olah Cache Version: {h.version}")
+        print(f"File Size: {_size_human(h.file_size)} ({h.file_size} B)")
+        print(f"On-Disk Size: {_size_human(on_disk)} ({on_disk} B)")
+        print(f"Block Size: {_size_human(h.block_size)}")
+        print(f"Chunk Size: {_size_human(h.chunk_size)}")
+        print(f"Compression: {h.compression_algo} (0=none,1=gzip,2=lzma)")
+        print(f"Etag: {h.etag.decode('utf-8', 'replace') if h.etag else '(none)'}")
+        print(f"Blocks: {cached}/{block_number} cached")
+        print("Cache Status:")
+        status = "".join("1" if p else "0" for p in present)
+        for i in range(0, len(status), 50):
+            print("  " + status[i:i + 50])
+
+        if args.export:
+            if block_number > 0 and cached == block_number:
+                import asyncio
+
+                async def _export():
+                    with open(args.export, "wb") as out:
+                        for idx in range(block_number):
+                            block = await cache.read_block(idx)
+                            if block is None:
+                                raise RuntimeError(f"block {idx} vanished during export")
+                            out.write(block[: cache._block_real_len(idx)])
+
+                asyncio.run(_export())
+                print(f"Exported {h.file_size} bytes to {args.export}")
+            else:
+                print("Some blocks are not cached, so the export is skipped.")
+    finally:
+        cache.close()
+    return 0
+
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Olah Cache Visualization Tool.")
-    parser.add_argument("--file", "-f", type=str, required=True, help="The path of Olah cache file")
-    parser.add_argument("--export", "-e", type=str, default="", help="Export the cached file if all blocks are cached")
-    args = parser.parse_args()
-    print(args)
-
-    with open(args.file, "rb") as f:
-        f.seek(0, os.SEEK_END)
-        bin_size = f.tell()
-    
-    try:
-        cache = OlahCache(args.file)
-    except Exception as e:
-        print(e)
-        sys.exit(1)
-    print(f"File: {args.file}")
-    print(f"Olah Cache Version: {cache.header.version}")
-    print(f"File Size: {get_size_human(cache.header.file_size)}")
-    print(f"Cache Total Size: {get_size_human(bin_size)}")
-    print(f"Block Size: {cache.header.block_size}")
-    print(f"Block Number: {cache.header.block_number}")
-    print(f"Cache Status: ")
-    cache_status = cache.header.block_mask.__str__()[:cache.header._block_number]
-    print(insert_newlines(cache_status, every=50))
-
-    if args.export != "":
-        if all([c == "1" for c in cache_status]):
-            with open(args.file, "rb") as f:
-                f.seek(cache._get_header_size(), os.SEEK_SET)
-                with open(args.export, "wb") as fout:
-                    fout.write(f.read())
-        else:
-            print("Some blocks are not cached, so the export is skipped.")
+    sys.exit(main())

--- a/src/olah/proxy/files.py
+++ b/src/olah/proxy/files.py
@@ -36,7 +36,6 @@ from olah.cache.olah_cache import (
 from olah.errors import error_entry_not_found, error_proxy_invalid_data, error_proxy_timeout
 from olah.proxy.pathsinfo import pathsinfo_generator
 from olah.utils.cache_utils import read_cache_request, write_cache_request
-from olah.utils.disk_utils import touch_file_access_time
 from olah.utils.url_utils import (
     RemoteInfo,
     add_query_param,
@@ -77,7 +76,7 @@ def get_contiguous_ranges(
     end_block = (end_pos - 1) // cache_file._get_block_size()
 
     range_start_pos = start_pos
-    range_is_remote = not cache_file.has_block(start_block)
+    range_is_remote = not cache_file.is_block_cached(start_block)
     cur_pos = start_pos
     # Get contiguous ranges: (range_start_pos, range_end_pos), is_remote
     ranges_and_cache_list: List[Tuple[Tuple[int, int], bool]] = []
@@ -86,7 +85,7 @@ def get_contiguous_ranges(
             cur_pos, cache_file._get_block_size(), cache_file._get_file_size()
         )
 
-        if cache_file.has_block(cur_block):
+        if cache_file.is_block_cached(cur_block):
             cur_is_remote = False
         else:
             cur_is_remote = True
@@ -312,6 +311,10 @@ async def _read_block_real_payload(
     except CacheIntegrityError:
         await cache_file._invalidate_block(block_index)
         raise
+    if padded is None:
+        # Block was evicted between has_block() and the read. Treat it like a
+        # corrupt block so the caller's single-flight path re-downloads it.
+        raise CacheIntegrityError(f"Block {block_index} vanished before read.")
     return padded[:real_len]
 
 
@@ -372,8 +375,15 @@ async def _fetch_block_single_flight(
                     raw_real if real_len == bs else raw_real + b"\x00" * (bs - real_len)
                 )
                 # _write_block_safely shields the publish so a leader disconnect
-                # still lands the block (followers depend on it).
-                await _write_block_safely(cache_file, block_index, raw_block, allow_cache=True)
+                # still lands the block (followers depend on it). If the entry was
+                # evicted mid-download (hourly cleanup removed blocks/), publishing
+                # is impossible -- treat it as best-effort and still return the
+                # fetched bytes so this client succeeds; a future request recreates
+                # the entry.
+                try:
+                    await _write_block_safely(cache_file, block_index, raw_block, allow_cache=True)
+                except FileNotFoundError:
+                    pass
                 return raw_real
             finally:
                 _release_lock(lock_fh)
@@ -391,10 +401,49 @@ async def _fetch_block_single_flight(
     )
 
 
+async def _yield_range_blocks(
+    *,
+    client: httpx.AsyncClient,
+    remote_info: RemoteInfo,
+    cache_file: OlahCache,
+    range_start_pos: int,
+    range_end_pos: int,
+    resume_pos: int,
+    allow_cache: bool,
+) -> AsyncIterator[bytes]:
+    """Yield the client-requested slice of each block in ``[resume_pos, range_end_pos)``.
+
+    Shared by the cache-MISS path (``resume_pos == range_start_pos``) and by the
+    cache-HIT recovery path (``resume_pos`` == where ``stream_range`` failed). Each
+    block goes through per-block single-flight, so a block evicted mid-response is
+    transparently re-fetched and the client still gets a complete, correct response.
+    """
+    bs = cache_file._get_block_size()
+    fs = cache_file._get_file_size()
+    first_block = resume_pos // bs
+    last_block = (range_end_pos - 1) // bs
+    for blk in range(first_block, last_block + 1):
+        block_start = blk * bs
+        block_end = min((blk + 1) * bs, fs)
+        block_bytes = await _fetch_block_single_flight(
+            client=client,
+            remote_info=remote_info,
+            cache_file=cache_file,
+            block_index=blk,
+            block_start=block_start,
+            block_end=block_end,
+            allow_cache=allow_cache,
+        )
+        lo = max(resume_pos, block_start) - block_start
+        hi = min(range_end_pos, block_end) - block_start
+        piece = block_bytes[lo:hi]
+        if piece:
+            yield piece
+
+
 async def _file_chunk_get(
     app,
     save_path: str,
-    head_path: str,
     client: httpx.AsyncClient,
     method: str,
     url: Optional[str],
@@ -413,7 +462,9 @@ async def _file_chunk_get(
     # to trust the disk. The constructor handles create / reuse / wipe uniformly
     # and sizes chunks.crc for new caches.
     # Opening a cache does mkdirs + advisory locking + (on create) fsync, all of
-    # which would block the event loop -- run it in the threadpool.
+    # which would block the event loop -- run it in the threadpool. Opening also
+    # bumps the entry's meta.lock mtime, which is the LRU access signal eviction
+    # sorts on (see olah.utils.disk_utils.collect_cache_units).
     cache_file = await fastapi.concurrency.run_in_threadpool(
         OlahCache,
         save_path,
@@ -424,8 +475,6 @@ async def _file_chunk_get(
         expected_etag=expected_etag,
     )
 
-    # Refresh access time
-    touch_file_access_time(save_path)
     try:
         _, all_ranges, _ = get_request_ranges(file_size, headers.get("range"))
 
@@ -447,39 +496,26 @@ async def _file_chunk_get(
                         raise Exception(
                             "cache miss in cache-only mode (no upstream URL available)"
                         )
-                    bs = cache_file._get_block_size()
-                    fs = cache_file._get_file_size()
                     remote_info = RemoteInfo(method, url, headers)
-                    first_block = range_start_pos // bs
-                    last_block = (range_end_pos - 1) // bs
-                    for blk in range(first_block, last_block + 1):
-                        block_start = blk * bs
-                        block_end = min((blk + 1) * bs, fs)
-                        block_bytes = await _fetch_block_single_flight(
-                            client=client,
-                            remote_info=remote_info,
-                            cache_file=cache_file,
-                            block_index=blk,
-                            block_start=block_start,
-                            block_end=block_end,
-                            allow_cache=allow_cache,
-                        )
-                        # Yield only the slice of the block the client asked for
-                        # (a range strictly inside one block still fetches the
-                        # whole block, since caching is block-granular).
-                        lo = max(range_start_pos, block_start) - block_start
-                        hi = min(range_end_pos, block_end) - block_start
-                        piece = block_bytes[lo:hi]
-                        if piece:
-                            yield piece
+                    async for piece in _yield_range_blocks(
+                        client=client,
+                        remote_info=remote_info,
+                        cache_file=cache_file,
+                        range_start_pos=range_start_pos,
+                        range_end_pos=range_end_pos,
+                        resume_pos=range_start_pos,
+                        allow_cache=allow_cache,
+                    ):
+                        yield piece
                 else:
                     # Cache hit: blocks are already on disk -- no reassembly, no
                     # cache writes. OlahCache.stream_range serves both uncompressed
                     # (raw seek+read) and compressed (sub-chunk-indexed) blocks in
-                    # ~1MB pieces, verifying each chunk's CRC. A CRC mismatch
-                    # raises CacheIntegrityError (the block is invalidated so the
-                    # next request re-fetches); we let it abort this response
-                    # rather than serve unverified bytes.
+                    # ~1MB pieces, verifying each chunk's CRC. If a block vanishes
+                    # mid-stream (eviction) or fails CRC, stream_range raises
+                    # CacheIntegrityError; we fall back to per-block single-flight
+                    # for the unsent remainder so the client still gets a complete,
+                    # correct response instead of a truncated 500.
                     cur_pos = range_start_pos
                     try:
                         async for piece in cache_file.stream_range(
@@ -489,7 +525,22 @@ async def _file_chunk_get(
                                 yield piece
                                 cur_pos += len(piece)
                     except CacheIntegrityError:
-                        raise
+                        if url is None:
+                            # Cache-only mode cannot re-fetch; let it surface.
+                            raise
+                        remote_info = RemoteInfo(method, url, headers)
+                        async for piece in _yield_range_blocks(
+                            client=client,
+                            remote_info=remote_info,
+                            cache_file=cache_file,
+                            range_start_pos=range_start_pos,
+                            range_end_pos=range_end_pos,
+                            resume_pos=cur_pos,
+                            allow_cache=allow_cache,
+                        ):
+                            if piece:
+                                yield piece
+                                cur_pos += len(piece)
                     if cur_pos != range_end_pos:
                         raise Exception(
                             f"The size of cached range ({range_end_pos - range_start_pos}) is different from sent size ({cur_pos - range_start_pos})."
@@ -501,7 +552,6 @@ async def _file_chunk_get(
 async def _stream_single_range(
     app,
     save_path: str,
-    head_path: str,
     client: httpx.AsyncClient,
     method: str,
     url: Optional[str],
@@ -521,7 +571,6 @@ async def _stream_single_range(
     async for chunk in _file_chunk_get(
         app=app,
         save_path=save_path,
-        head_path=head_path,
         client=client,
         method=method,
         url=url,
@@ -536,7 +585,6 @@ async def _stream_single_range(
 async def _file_chunk_head(
     app,
     save_path: str,
-    head_path: str,
     client: httpx.AsyncClient,
     method: str,
     url: str,
@@ -703,7 +751,6 @@ async def _try_redirect_to_content_route(
 async def _file_realtime_stream(
     app,
     save_path: str,
-    head_path: str,
     url: str,
     request: Request,
     repo_type: Optional[Literal["models", "datasets", "spaces"]] = None,
@@ -832,14 +879,13 @@ async def _file_realtime_stream(
     if expected_etag is not None:
         etag = expected_etag
     return await _build_file_response(
-        app, save_path, head_path, request_headers, method, hf_url, file_size, etag, allow_cache, commit
+        app, save_path, request_headers, method, hf_url, file_size, etag, allow_cache, commit
     )
 
 
 async def _build_file_response(
     app,
     save_path: str,
-    head_path: str,
     request_headers: Dict[str, str],
     method: str,
     upstream_url: Optional[str],
@@ -905,7 +951,6 @@ async def _build_file_response(
                     async for each_chunk in _stream_single_range(
                         app=app,
                         save_path=save_path,
-                        head_path=head_path,
                         client=client,
                         method=method,
                         url=upstream_url,
@@ -919,7 +964,6 @@ async def _build_file_response(
                     async for each_chunk in _stream_single_range(
                         app=app,
                         save_path=save_path,
-                        head_path=head_path,
                         client=client,
                         method=method,
                         url=upstream_url,
@@ -936,7 +980,6 @@ async def _build_file_response(
                         async for each_chunk in _stream_single_range(
                             app=app,
                             save_path=save_path,
-                            head_path=head_path,
                             client=client,
                             method=method,
                             url=upstream_url,
@@ -953,7 +996,6 @@ async def _build_file_response(
                 async for each_chunk in _file_chunk_head(
                     app=app,
                     save_path=save_path,
-                    head_path=head_path,
                     client=client,
                     method=method,
                     url=upstream_url,
@@ -981,16 +1023,11 @@ async def file_get_generator(
     org_repo = get_org_repo(org, repo)
     # save
     repos_path = app.state.app_settings.config.repos_path
-    head_path = os.path.join(
-        repos_path, f"heads/{repo_type}/{org_repo}/resolve/{commit}/{file_path}"
-    )
     save_path = os.path.join(
         repos_path, f"files/{repo_type}/{org_repo}/resolve/{commit}/{file_path}"
     )
-    make_dirs(head_path)
     make_dirs(save_path)
 
-    # use_cache = os.path.exists(head_path) and os.path.exists(save_path)
     allow_cache = await check_cache_rules_hf(app, repo_type, org, repo)
 
     # proxy
@@ -1011,7 +1048,6 @@ async def file_get_generator(
         repo=repo,
         file_path=file_path,
         save_path=save_path,
-        head_path=head_path,
         url=url,
         request=request,
         method=method,
@@ -1035,29 +1071,16 @@ async def cdn_file_get_generator(
     org_repo = get_org_repo(org, repo)
     # save
     repos_path = app.state.app_settings.config.repos_path
-    head_path = os.path.join(
-        repos_path, f"heads/{repo_type}/{org_repo}/cdn/{file_hash}"
-    )
     save_path = os.path.join(
         repos_path, f"files/{repo_type}/{org_repo}/cdn/{file_hash}"
     )
-    make_dirs(head_path)
     make_dirs(save_path)
 
-    # use_cache = os.path.exists(head_path) and os.path.exists(save_path)
     allow_cache = await check_cache_rules_hf(app, repo_type, org, repo)
-
-    # proxy
-    # request_url = urlparse(str(request.url))
-    # if request_url.netloc == app.state.app_settings.config.hf_lfs_netloc:
-    #     redirected_url = urljoin(app.state.app_settings.config.mirror_lfs_url_base(), get_url_tail(request_url))
-    # else:
-    #     redirected_url = urljoin(app.state.app_settings.config.mirror_url_base(), get_url_tail(request_url))
 
     return await _file_realtime_stream(
         app=app,
         save_path=save_path,
-        head_path=head_path,
         url=str(request.url),
         request=request,
         method=method,

--- a/src/olah/proxy/lfs.py
+++ b/src/olah/proxy/lfs.py
@@ -24,13 +24,9 @@ async def lfs_head_generator(
 ):
     # save
     repos_path = app.state.app_settings.config.repos_path
-    head_path = os.path.join(
-        repos_path, f"lfs/heads/{dir1}/{dir2}/{hash_repo}/{hash_file}"
-    )
     save_path = os.path.join(
         repos_path, f"lfs/files/{dir1}/{dir2}/{hash_repo}/{hash_file}"
     )
-    make_dirs(head_path)
     make_dirs(save_path)
 
     # LFS objects are content-addressed: hash_file IS the SHA-256 of the blob, so
@@ -40,7 +36,6 @@ async def lfs_head_generator(
     return await _file_realtime_stream(
         app=app,
         save_path=save_path,
-        head_path=head_path,
         url=str(request.url),
         request=request,
         method="HEAD",
@@ -61,19 +56,14 @@ async def lfs_get_generator(
 ):
     # save
     repos_path = app.state.app_settings.config.repos_path
-    head_path = os.path.join(
-        repos_path, f"lfs/heads/{dir1}/{dir2}/{hash_repo}/{hash_file}"
-    )
     save_path = os.path.join(
         repos_path, f"lfs/files/{dir1}/{dir2}/{hash_repo}/{hash_file}"
     )
-    make_dirs(head_path)
     make_dirs(save_path)
 
     return await _file_realtime_stream(
         app=app,
         save_path=save_path,
-        head_path=head_path,
         url=str(request.url),
         request=request,
         method="GET",

--- a/src/olah/proxy/xet.py
+++ b/src/olah/proxy/xet.py
@@ -123,9 +123,7 @@ async def xet_get_generator(
 
     repos_path = app.state.app_settings.config.repos_path
     save_path = os.path.join(repos_path, "lfs", "files", "xet", xet_hash)
-    head_path = os.path.join(repos_path, "lfs", "heads", "xet", xet_hash)
     make_dirs(save_path)
-    make_dirs(head_path)
 
     request_headers = {k: v for k, v in request.headers.items() if k.lower() != "host"}
     # The signed CDN URL is self-authorizing; drop the bearer token so the CDN
@@ -150,7 +148,6 @@ async def xet_get_generator(
             return await _build_file_response(
                 app=app,
                 save_path=save_path,
-                head_path=head_path,
                 request_headers=request_headers,
                 method=method,
                 upstream_url=None,
@@ -176,7 +173,6 @@ async def xet_get_generator(
     return await _build_file_response(
         app=app,
         save_path=save_path,
-        head_path=head_path,
         request_headers=request_headers,
         method=method,
         upstream_url=signed_url,

--- a/src/olah/server.py
+++ b/src/olah/server.py
@@ -6,14 +6,14 @@
 # https://opensource.org/licenses/MIT.
 
 import argparse
-import datetime
 import os
 import sys
 import time
 from contextlib import asynccontextmanager
-from typing import Sequence, Tuple, Union
+from typing import Sequence, Union
 
 import httpx
+import fastapi.concurrency
 from fastapi import FastAPI
 from fastapi.templating import Jinja2Templates
 from fastapi_utils.tasks import repeat_every
@@ -35,10 +35,7 @@ from olah.server_routes import (
 from olah.utils.disk_utils import (
     convert_bytes_to_human_readable,
     convert_to_bytes,
-    get_folder_size,
-    sort_files_by_access_time,
-    sort_files_by_modify_time,
-    sort_files_by_size,
+    evict_cache_to_limit,
 )
 from olah.utils.logging import build_logger
 
@@ -115,40 +112,21 @@ async def check_disk_usage() -> None:
         return
 
     limit_size = app.state.app_settings.config.cache_size_limit
-    current_size = get_folder_size(app.state.app_settings.config.repos_path)
+    strategy = app.state.app_settings.config.cache_clean_strategy
+    repos_path = app.state.app_settings.config.repos_path
 
-    limit_size_h = convert_bytes_to_human_readable(limit_size)
-    current_size_h = convert_bytes_to_human_readable(current_size)
-
-    if current_size < limit_size:
-        return
-    print(f"Cache size exceeded! Limit: {limit_size_h}, Current: {current_size_h}.")
-    print("Cleaning...")
-    files_path = os.path.join(app.state.app_settings.config.repos_path, "files")
-    lfs_path = os.path.join(app.state.app_settings.config.repos_path, "lfs")
-
-    files: Sequence[Tuple[str, Union[int, datetime.datetime]]] = []
-    if app.state.app_settings.config.cache_clean_strategy == "LRU":
-        files = sort_files_by_access_time(files_path) + sort_files_by_access_time(lfs_path)
-        files = sorted(files, key=lambda x: x[1])
-    elif app.state.app_settings.config.cache_clean_strategy == "FIFO":
-        files = sort_files_by_modify_time(files_path) + sort_files_by_modify_time(lfs_path)
-        files = sorted(files, key=lambda x: x[1])
-    elif app.state.app_settings.config.cache_clean_strategy == "LARGE_FIRST":
-        files = sort_files_by_size(files_path) + sort_files_by_size(lfs_path)
-        files = sorted(files, key=lambda x: x[1], reverse=True)
-
-    for filepath, _ in files:
-        if current_size < limit_size:
-            break
-        filesize = os.path.getsize(filepath)
-        os.remove(filepath)
-        current_size -= filesize
-        print(f"Remove file: {filepath}. File Size: {convert_bytes_to_human_readable(filesize)}")
-
-    current_size = get_folder_size(app.state.app_settings.config.repos_path)
-    current_size_h = convert_bytes_to_human_readable(current_size)
-    print(f"Cleaning finished. Limit: {limit_size_h}, Current: {current_size_h}.")
+    # The whole scan + evict is synchronous (os.walk + shutil.rmtree); run it off
+    # the event loop so a TB-scale cache tree doesn't stall request handling. The
+    # collector does ONE walk for both total size and eviction candidates, evicts
+    # whole cache entries (never individual block files), and skips any entry
+    # whose meta.lock is held (in active open/create/resize).
+    after_size = await fastapi.concurrency.run_in_threadpool(
+        evict_cache_to_limit, repos_path, limit_size, strategy
+    )
+    print(
+        f"Cache cleanup: Limit={convert_bytes_to_human_readable(limit_size)}, "
+        f"Current={convert_bytes_to_human_readable(after_size)}, Strategy={strategy}."
+    )
 
 
 @asynccontextmanager

--- a/src/olah/utils/cache_utils.py
+++ b/src/olah/utils/cache_utils.py
@@ -7,7 +7,15 @@
 
 
 import json
+import os
 from typing import Dict, Mapping, Union
+
+from olah.utils.file_utils import atomic_write_bytes, atomic_write_text
+
+
+def _body_path(save_path: str) -> str:
+    """Sidecar path for the raw response body, alongside the JSON metadata."""
+    return save_path + ".body"
 
 
 async def write_cache_request(
@@ -16,41 +24,50 @@ async def write_cache_request(
     headers: Union[Dict[str, str], Mapping],
     content: bytes,
 ) -> None:
-    """
-    Write the request's status code, headers, and content to a cache file.
+    """Atomically persist a cached API response as JSON metadata + raw body.
 
-    Args:
-        head_path (str): The path to the cache file.
-        status_code (int): The status code of the request.
-        headers (Dict[str, str]): The dictionary of response headers.
-        content (bytes): The content of the request.
-
-    Returns:
-        None
+    Metadata (status + headers) goes to ``save_path``; the raw response bytes go
+    to a sibling ``<save_path>.body`` sidecar, stored verbatim rather than
+    hex-encoded (the legacy inline-hex format doubled the on-disk size). Both
+    files are written tmp+fsync+rename so a crash or a concurrent reader never
+    observes a truncated file.
     """
     if not isinstance(headers, dict):
         headers = {k.lower(): v for k, v in headers.items()}
-    rq = {
-        "status_code": status_code,
-        "headers": headers,
-        "content": content.hex(),
-    }
-    with open(save_path, "w", encoding="utf-8") as f:
-        f.write(json.dumps(rq, ensure_ascii=False))
+    rq = {"status_code": status_code, "headers": headers}
+    atomic_write_text(save_path, json.dumps(rq, ensure_ascii=False))
+    atomic_write_bytes(_body_path(save_path), bytes(content))
 
 
-async def read_cache_request(save_path: str) -> Dict[str, str]:
+async def read_cache_request(save_path: str) -> Dict:
+    """Load a cached API response -> ``{status_code, headers, content}``.
+
+    Prefers the raw ``.body`` sidecar; falls back to the legacy inline-hex
+    ``content`` field for caches written before the sidecar split. Bumps the
+    files' mtimes as a reliable last-access signal for LRU eviction (FS atime is
+    unreliable under noatime/relatime).
     """
-    Read the request's status code, headers, and content from a cache file.
+    body_path = _body_path(save_path)
 
-    Args:
-        save_path (str): The path to the cache file.
-
-    Returns:
-        Dict[str, str]: A dictionary containing the status code, headers, and content of the request.
-    """
     with open(save_path, "r", encoding="utf-8") as f:
         rq = json.loads(f.read())
 
+    if os.path.exists(body_path):
+        with open(body_path, "rb") as f:
+            rq["content"] = f.read()
+        _touch(save_path)
+        _touch(body_path)
+        return rq
+
+    # Legacy format: content hex-encoded inline in the JSON.
     rq["content"] = bytes.fromhex(rq["content"])
+    _touch(save_path)
     return rq
+
+
+def _touch(path: str) -> None:
+    """Best-effort bump of a file's mtime (LRU access marker)."""
+    try:
+        os.utime(path, None)
+    except OSError:
+        pass

--- a/src/olah/utils/disk_utils.py
+++ b/src/olah/utils/disk_utils.py
@@ -5,81 +5,194 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-import datetime
 import os
+import shutil
+from typing import Dict, List, Optional, Tuple
 
-import time
-from typing import List, Optional, Tuple
+import portalocker
 
 
 def get_folder_size(folder_path: str) -> int:
-    total_size = 0
-    for dirpath, dirnames, filenames in os.walk(folder_path):
+    """Total bytes under ``folder_path`` (recursive). Used for size reporting."""
+    total = 0
+    for dirpath, _dirnames, filenames in os.walk(folder_path):
+        for f in filenames:
+            try:
+                total += os.path.getsize(os.path.join(dirpath, f))
+            except OSError:
+                pass
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Cache eviction
+# ---------------------------------------------------------------------------
+#
+# Eviction operates on two kinds of units, collected in a single tree walk:
+#   * "entry" -- a block-cache directory (one containing ``meta.bin``). Evicted
+#     as a WHOLE via ``shutil.rmtree``; individual block files are never deleted
+#     on their own, since that would leave ``meta.bin`` / ``chunks.crc`` behind
+#     pointing at missing blocks (a corrupt entry). Before removing, a
+#     non-blocking exclusive lock on the entry's ``meta.lock`` is attempted; if
+#     it is held (a worker is mid open / create / resize), the entry is skipped
+#     so eviction never races cache creation.
+#   * "json" -- a loose cached API response under ``api/`` (``<name>.json`` plus
+#     its ``<name>.body`` sidecar), evicted together.
+#
+# Ordering uses each unit's mtime (oldest first) for LRU/FIFO, or size (largest
+# first) for LARGE_FIRST. mtime -- NOT atime -- drives LRU: atime is unreliable
+# under noatime/relatime, and the old code bumped the *directory* atime which
+# never propagated to the block files anyway. ``OlahCache.open`` bumps the
+# entry's ``meta.lock`` mtime and ``read_cache_request`` bumps API-JSON mtime, so
+# mtime is a faithful per-unit access signal.
+
+
+def _ancestor_entry_root(dirpath: str, entry_roots: dict) -> Optional[str]:
+    """Return the cache-entry root that owns ``dirpath`` (an ancestor with
+    ``meta.bin``), or ``None`` if ``dirpath`` is not inside a cache entry."""
+    cur = dirpath
+    while True:
+        if cur in entry_roots:
+            return cur
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            return None
+        cur = parent
+
+
+def collect_cache_units(
+    repos_path: str,
+) -> Tuple[int, List[Dict]]:
+    """Single-pass scan of the cache tree -> ``(total_bytes, units)``.
+
+    Each unit is ``{"path", "size", "mtime", "kind"}`` (``kind`` is ``"entry"``
+    or ``"json"``). Every regular file under ``repos_path`` contributes to
+    ``total_bytes``; files inside a cache entry are attributed to that entry's
+    unit, loose ``*.json`` API responses become ``"json"`` units (with their
+    ``.body`` sidecar folded in), and ``*.json.body`` sidecars are not double
+    counted.
+    """
+    # Pass 1: locate cache-entry roots (dirs containing meta.bin) + their mtimes.
+    entry_roots: Dict[str, float] = {}
+    for dirpath, _ds, filenames in os.walk(repos_path):
+        if "meta.bin" in filenames:
+            lock_path = os.path.join(dirpath, "meta.lock")
+            try:
+                if os.path.exists(lock_path):
+                    mtime = os.stat(lock_path).st_mtime
+                else:
+                    mtime = os.stat(os.path.join(dirpath, "meta.bin")).st_mtime
+            except OSError:
+                mtime = 0.0
+            entry_roots[dirpath] = mtime
+
+    # Pass 2: attribute each file's size to its entry or to a loose JSON unit.
+    total = 0
+    entry_sizes: Dict[str, int] = {r: 0 for r in entry_roots}
+    json_meta: Dict[str, List] = {}  # json_path -> [size, mtime]
+    for dirpath, _ds, filenames in os.walk(repos_path):
+        root = _ancestor_entry_root(dirpath, entry_roots)
         for f in filenames:
             fp = os.path.join(dirpath, f)
-            total_size += os.path.getsize(fp)
-    return total_size
-
-def sort_files_by_access_time(folder_path: str) -> List[Tuple[str, datetime.datetime]]:
-    files = []
-
-    # Get all file paths and time
-    for dirpath, dirnames, filenames in os.walk(folder_path):
-        for f in filenames:
-            file_path = os.path.join(dirpath, f)
-            if not os.path.isfile(file_path):
+            try:
+                st = os.stat(fp)
+            except OSError:
                 continue
-            access_time = datetime.datetime.fromtimestamp(os.path.getatime(file_path))
-            files.append((file_path, access_time))
-    
-    # Sort by accesstime
-    sorted_files = sorted(files, key=lambda x: x[1])
-    
-    return sorted_files
-
-def sort_files_by_modify_time(folder_path: str) -> List[Tuple[str, datetime.datetime]]:
-    files = []
-
-    # Get all file paths and time
-    for dirpath, dirnames, filenames in os.walk(folder_path):
-        for f in filenames:
-            file_path = os.path.join(dirpath, f)
-            if not os.path.isfile(file_path):
+            total += st.st_size
+            if root is not None:
+                entry_sizes[root] += st.st_size
                 continue
-            access_time = datetime.datetime.fromtimestamp(os.path.getmtime(file_path))
-            files.append((file_path, access_time))
-    
-    # Sort by modify time
-    sorted_files = sorted(files, key=lambda x: x[1])
-    
-    return sorted_files
-
-def sort_files_by_size(folder_path: str) -> List[Tuple[str, int]]:
-    files = []
-
-    # Get all file paths and sizes
-    for dirpath, dirnames, filenames in os.walk(folder_path):
-        for f in filenames:
-            file_path = os.path.join(dirpath, f)
-            if not os.path.isfile(file_path):
+            # Loose file outside any cache entry.
+            if f.endswith(".json.body") and f[: -len(".body")] in filenames:
+                # Sidecar of a sibling .json in the same dir; counted with it.
                 continue
-            file_size = os.path.getsize(file_path)
-            files.append((file_path, file_size))
-    
-    # Sort by file size
-    sorted_files = sorted(files, key=lambda x: x[1])
-    
-    return sorted_files
+            if f.endswith(".json"):
+                unit = json_meta.setdefault(fp, [0, st.st_mtime])
+                unit[0] += st.st_size
+                sidecar = fp + ".body"
+                if os.path.exists(sidecar):
+                    try:
+                        unit[0] += os.stat(sidecar).st_size
+                    except OSError:
+                        pass
 
-def touch_file_access_time(filename: str):
-    if not os.path.exists(filename):
-        return
-    now = time.time()
-    stat_info = os.stat(filename)
-    atime = stat_info.st_atime
-    mtime = stat_info.st_mtime
-    
-    os.utime(filename, times=(now, mtime))
+    units: List[Dict] = []
+    for root, mtime in entry_roots.items():
+        size = entry_sizes[root]
+        if size > 0:
+            units.append({"path": root, "size": size, "mtime": mtime, "kind": "entry"})
+    for jp, (size, mtime) in json_meta.items():
+        units.append({"path": jp, "size": size, "mtime": mtime, "kind": "json"})
+    return total, units
+
+
+def _try_evict_entry(entry_dir: str) -> bool:
+    """Remove a whole cache entry unless its ``meta.lock`` is held (in use).
+
+    Acquiring ``LOCK_EX | LOCK_NB`` on ``meta.lock`` succeeds only when no worker
+    is mid open / create / resize; a streaming read holds block-file SH locks,
+    not ``meta.lock``, so an in-flight read is safe (its open fds survive the
+    rmtree on POSIX, and reads are resilient to a vanished block anyway).
+    """
+    lock_path = os.path.join(entry_dir, "meta.lock")
+    try:
+        fh = open(lock_path, "a+")
+    except OSError:
+        return False
+    try:
+        portalocker.lock(fh, portalocker.LOCK_EX | portalocker.LOCK_NB)
+    except portalocker.LockException:
+        fh.close()
+        return False
+    try:
+        shutil.rmtree(entry_dir, ignore_errors=True)
+        return not os.path.exists(entry_dir)
+    finally:
+        try:
+            portalocker.unlock(fh)
+        except Exception:
+            pass
+        try:
+            fh.close()
+        except Exception:
+            pass
+
+
+def _evict_json(json_path: str) -> None:
+    for p in (json_path, json_path + ".body"):
+        try:
+            os.remove(p)
+        except OSError:
+            pass
+
+
+def evict_cache_to_limit(repos_path: str, limit: int, strategy: str = "LRU") -> int:
+    """Evict whole cache entries + loose API JSON until ``total <= limit``.
+
+    Returns the post-eviction total byte count (best-effort; concurrent writers
+    may change it between collection and removal). Never evicts individual block
+    files. See the module docstring for the full rationale.
+    """
+    total, units = collect_cache_units(repos_path)
+    if total <= limit:
+        return total
+    if strategy == "LARGE_FIRST":
+        units.sort(key=lambda u: u["size"], reverse=True)
+    else:
+        # LRU and FIFO both order by mtime asc (oldest first); FIFO approximates
+        # write/creation order via mtime, which is the closest reliable signal.
+        units.sort(key=lambda u: u["mtime"])
+    for u in units:
+        if total <= limit:
+            break
+        if u["kind"] == "entry":
+            if _try_evict_entry(u["path"]):
+                total -= u["size"]
+        else:
+            _evict_json(u["path"])
+            total -= u["size"]
+    return total
+
 
 def convert_to_bytes(size_str) -> Optional[int]:
     if size_str is None:

--- a/src/olah/utils/file_utils.py
+++ b/src/olah/utils/file_utils.py
@@ -6,6 +6,7 @@
 # https://opensource.org/licenses/MIT.
 
 import os
+import threading
 
 
 def make_dirs(path: str):
@@ -15,3 +16,39 @@ def make_dirs(path: str):
         save_dir = os.path.dirname(path)
     if not os.path.exists(save_dir):
         os.makedirs(save_dir, exist_ok=True)
+
+
+def fsync_dir(dir_path: str) -> None:
+    """Best-effort fsync of a directory so a rename within it is durable."""
+    try:
+        fd = os.open(dir_path, os.O_RDONLY)
+        try:
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+    except OSError:
+        pass
+
+
+def atomic_write_bytes(path: str, data: bytes) -> None:
+    """Write ``data`` to ``path`` atomically: unique tmp -> fsync -> os.replace.
+
+    A concurrent reader or a crash mid-write never observes a truncated file:
+    the destination appears either wholly old or wholly new.
+    """
+    parent = os.path.dirname(path) or "."
+    os.makedirs(parent, exist_ok=True)
+    tmp_path = os.path.join(
+        parent, f".{os.path.basename(path)}.{os.getpid()}.{threading.get_ident()}.tmp"
+    )
+    with open(tmp_path, "wb") as f:
+        f.write(data)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, path)
+    fsync_dir(parent)
+
+
+def atomic_write_text(path: str, text: str, encoding: str = "utf-8") -> None:
+    """Atomically write ``text`` (encoded utf-8 by default) to ``path``."""
+    atomic_write_bytes(path, text.encode(encoding))

--- a/src/olah/utils/repo_utils.py
+++ b/src/olah/utils/repo_utils.py
@@ -72,9 +72,10 @@ def _load_meta_head_object(file_path: str) -> Optional[Dict]:
 
     * a plain mirror ``RepoMeta`` document (``{"sha": ..., "lastModified": ...}``)
     * a proxy HTTP cache envelope written by ``write_cache_request``
-      (``{"status_code", "headers", "content": "<hex>"}``), whose ``content``
-      holds the (possibly gzip-compressed) revision API payload. HEAD caches
-      carry an empty body and therefore contribute no revision info.
+      (``{"status_code", "headers"}`` with the body in a sibling ``.body``
+      sidecar; legacy envelopes also accepted with the body inline as hex
+      ``content``). HEAD caches carry an empty body and therefore contribute no
+      revision info.
 
     Returns the inner revision object, or ``None`` if the file cannot be parsed
     as revision metadata.
@@ -85,13 +86,20 @@ def _load_meta_head_object(file_path: str) -> Optional[Dict]:
     except (OSError, ValueError):
         return None
 
-    if isinstance(raw, dict) and "content" in raw and "status_code" in raw:
-        # Proxy cache envelope: unwrap and decode the real payload.
+    body_path = file_path + ".body"
+    is_envelope = isinstance(raw, dict) and (
+        "status_code" in raw or os.path.exists(body_path)
+    )
+    if is_envelope:
+        # Proxy cache envelope written by write_cache_request: the body lives in
+        # a sibling .body sidecar (new) or inline as hex (legacy).
         try:
-            request_cache = {
-                "content": bytes.fromhex(raw["content"]),
-                "headers": raw.get("headers", {}),
-            }
+            if os.path.exists(body_path):
+                with open(body_path, "rb") as bf:
+                    content = bf.read()
+            else:
+                content = bytes.fromhex(raw.get("content", ""))
+            request_cache = {"content": content, "headers": raw.get("headers", {})}
             return _load_cached_json_payload(request_cache)
         except (ValueError, OSError, EOFError, zlib.error):
             return None

--- a/tests/test_cache_present_map.py
+++ b/tests/test_cache_present_map.py
@@ -1,0 +1,130 @@
+# coding=utf-8
+# Copyright 2024 XiaHan
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+"""Tests for the v10 in-memory presence bitmap and resilient reads.
+
+The bitmap (revived ``cache/bitset.py``) is built once per ``open()`` from a
+single ``blocks/`` scan and kept in sync with writes/invalidations, so bulk
+iterators avoid a stat-per-block. ``read_block``/``stream_range`` must also
+tolerate a block vanishing mid-request (whole-entry eviction) without surfacing
+an opaque 500.
+"""
+
+import asyncio
+import os
+
+import pytest
+
+pytest.importorskip("portalocker")
+
+from olah.cache.olah_cache import CacheIntegrityError, OlahCache  # noqa: E402
+
+BLOCK = 64
+
+
+def _new_cache(tmp_path, name, payload, etag):
+    sp = os.path.join(str(tmp_path), name)
+    c = OlahCache(sp, file_size=len(payload), block_size=BLOCK,
+                  chunk_size=BLOCK, expected_etag=etag)
+    return c, sp
+
+
+def _fill(c, payload):
+    async def go():
+        n = (len(payload) + BLOCK - 1) // BLOCK
+        for i in range(n):
+            chunk = payload[i * BLOCK:(i + 1) * BLOCK]
+            await c.write_block(i, chunk + b"\x00" * (BLOCK - len(chunk)))
+
+    asyncio.run(go())
+
+
+def test_bitmap_agrees_with_disk_after_write_and_invalidate(tmp_path):
+    payload = bytes((i * 7) % 256 for i in range(150))  # 3 blocks (last partial)
+    c, _ = _new_cache(tmp_path, "c", payload, "etag-a")
+    _fill(c, payload)
+
+    # Bitmap mirrors the authoritative has_block() for every block.
+    assert [c.is_block_cached(i) for i in range(3)] == [True, True, True]
+    assert c.is_fully_cached()
+    assert [c.has_block(i) for i in range(3)] == [c.is_block_cached(i) for i in range(3)]
+
+    asyncio.run(c._invalidate_block(1))
+    assert c.is_block_cached(1) is False
+    assert c.is_fully_cached() is False
+    c.close()
+
+
+def test_bitmap_is_rebuilt_from_disk_on_reopen(tmp_path):
+    payload = bytes((i * 7) % 256 for i in range(150))
+    c, sp = _new_cache(tmp_path, "c", payload, "etag-a")
+    _fill(c, payload)
+    asyncio.run(c._invalidate_block(0))
+    c.close()
+
+    c2 = OlahCache(sp, expected_etag="etag-a")
+    try:
+        # Rebuilt from a fresh blocks/ scan, independent of the prior instance.
+        assert c2.is_block_cached(0) is False
+        assert c2.is_block_cached(1) is True
+        assert c2.is_fully_cached() is False
+    finally:
+        c2.close()
+
+
+def test_bitmap_reflects_new_blocks_after_resize(tmp_path):
+    payload = bytes((i * 7) % 256 for i in range(64))  # 1 block
+    c, _ = _new_cache(tmp_path, "c", payload, "etag-a")
+    _fill(c, payload)
+    assert c.is_fully_cached()
+
+    c.resize(3 * BLOCK)  # grow to 3 blocks
+    try:
+        # Block 0 still present; blocks 1, 2 are new and absent.
+        assert c.is_block_cached(0) is True
+        assert c.is_block_cached(1) is False
+        assert c.is_block_cached(2) is False
+        assert c.is_fully_cached() is False
+    finally:
+        c.close()
+
+
+def test_read_block_returns_none_for_block_removed_mid_request(tmp_path):
+    """A block evicted between has_block() and the read yields None, not a raise."""
+    payload = bytes((i * 7) % 256 for i in range(150))
+    c, sp = _new_cache(tmp_path, "c", payload, "etag-a")
+    _fill(c, payload)
+    c.close()
+
+    reader = OlahCache(sp, expected_etag="etag-a")
+    try:
+        # Simulate whole-entry eviction removing one block out from under us.
+        os.remove(os.path.join(sp, "blocks", "block_00000001.bin"))
+        assert asyncio.run(reader.read_block(1)) is None
+    finally:
+        reader.close()
+
+
+def test_stream_range_raises_typed_error_for_vanished_block(tmp_path):
+    """A missing block mid-stream surfaces CacheIntegrityError (recoverable),
+    not the old opaque 'read block which has not been cached' 500."""
+    payload = bytes((i * 7) % 256 for i in range(150))
+    c, sp = _new_cache(tmp_path, "c", payload, "etag-a")
+    _fill(c, payload)
+    c.close()
+
+    reader = OlahCache(sp, expected_etag="etag-a")
+    try:
+        os.remove(os.path.join(sp, "blocks", "block_00000001.bin"))
+        with pytest.raises(CacheIntegrityError):
+            asyncio.run(_collect(reader.stream_range(0, len(payload))))
+    finally:
+        reader.close()
+
+
+async def _collect(gen):
+    return b"".join([x async for x in gen])

--- a/tests/test_cache_utils.py
+++ b/tests/test_cache_utils.py
@@ -1,0 +1,84 @@
+# coding=utf-8
+# Copyright 2024 XiaHan
+#
+# Use of this source code is governed by an MIT-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/MIT.
+
+"""Tests for the API-response request cache (cache_utils).
+
+Covers: atomic write (tmp+rename, no leftover .tmp), the JSON+raw-sidecar split
+that replaces the old hex-doubled inline format, and backward-compatible reads of
+legacy inline-hex caches.
+"""
+
+import asyncio
+import glob
+import json
+import os
+
+from olah.utils.cache_utils import read_cache_request, write_cache_request
+
+
+def test_write_splits_json_and_raw_body_sidecar(tmp_path):
+    save = str(tmp_path / "api" / "meta_get.json")
+    content = bytes(range(256)) * 4  # 1024 bytes incl. all byte values
+
+    asyncio.run(write_cache_request(save, 206, {"ETag": '"abc"', "X": "y"}, content))
+
+    # The body lives in a sibling .body sidecar verbatim (NOT hex-doubled in JSON).
+    assert os.path.exists(save)
+    assert os.path.exists(save + ".body")
+    assert os.path.getsize(save + ".body") == len(content)
+    with open(save + ".body", "rb") as f:
+        assert f.read() == content
+    # The JSON no longer carries the body inline.
+    with open(save, "r", encoding="utf-8") as f:
+        assert "content" not in json.load(f)
+
+
+def test_read_roundtrips_json_and_raw_body(tmp_path):
+    save = str(tmp_path / "x.json")
+    content = b"\x00\x01\x02 hello \xff\xfe"
+    asyncio.run(write_cache_request(save, 200, {"a": "b"}, content))
+
+    rq = asyncio.run(read_cache_request(save))
+    assert rq["status_code"] == 200
+    assert rq["headers"] == {"a": "b"}
+    assert rq["content"] == content
+
+
+def test_read_falls_back_to_legacy_inline_hex(tmp_path):
+    save = str(tmp_path / "legacy.json")
+    content = b"legacy-body\x00\xff"
+    with open(save, "w", encoding="utf-8") as f:
+        f.write(json.dumps({"status_code": 200, "headers": {"h": "1"}, "content": content.hex()}))
+
+    rq = asyncio.run(read_cache_request(save))
+    assert rq["status_code"] == 200
+    assert rq["headers"] == {"h": "1"}
+    assert rq["content"] == content
+
+
+def test_write_is_atomic_no_tmp_leftover_and_valid(tmp_path):
+    """A completed write leaves no .tmp files and a reader sees a complete file."""
+    save = str(tmp_path / "a.json")
+    asyncio.run(write_cache_request(save, 200, {"k": "v"}, b"payload"))
+
+    leftovers = [p for p in glob.glob(str(tmp_path / "*.tmp"))]
+    assert leftovers == [], f"atomic write left tmp files: {leftovers}"
+
+    # A concurrent/late reader always gets a well-formed, complete record.
+    rq = asyncio.run(read_cache_request(save))
+    assert rq["content"] == b"payload" and rq["status_code"] == 200
+
+
+def test_overwrite_replaces_both_files_atomically(tmp_path):
+    save = str(tmp_path / "a.json")
+    asyncio.run(write_cache_request(save, 200, {"v": "1"}, b"one"))
+    asyncio.run(write_cache_request(save, 201, {"v": "2"}, b"two"))
+
+    rq = asyncio.run(read_cache_request(save))
+    assert rq["status_code"] == 201
+    assert rq["headers"] == {"v": "2"}
+    assert rq["content"] == b"two"

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -193,7 +193,6 @@ async def test_single_flight_dedups_concurrent_block_downloads(tmp_path):
             proxy_files._file_chunk_get(
                 app=app,
                 save_path=str(save_path),
-                head_path=str(tmp_path / "head"),
                 client=client,
                 method="GET",
                 url="https://huggingface.co/team/demo/resolve/main/blob.bin",
@@ -241,7 +240,6 @@ async def test_single_flight_recovers_when_leader_dies(tmp_path):
             proxy_files._file_chunk_get(
                 app=app,
                 save_path=str(save_path),
-                head_path=str(tmp_path / "head"),
                 client=client,
                 method="GET",
                 url="https://huggingface.co/team/demo/resolve/main/blob.bin",

--- a/tests/test_disk_and_file_utils.py
+++ b/tests/test_disk_and_file_utils.py
@@ -1,79 +1,134 @@
+import asyncio
 import os
 
+import portalocker
+import pytest
+
 from olah.utils.disk_utils import (
+    collect_cache_units,
     convert_bytes_to_human_readable,
     convert_to_bytes,
+    evict_cache_to_limit,
     get_folder_size,
-    sort_files_by_access_time,
-    sort_files_by_modify_time,
-    sort_files_by_size,
-    touch_file_access_time,
 )
 from olah.utils.file_utils import make_dirs
 
+# Eviction correctness depends on real fcntl.flock mutual exclusion.
+pytest.importorskip("portalocker")
+
+from olah.cache.olah_cache import OlahCache  # noqa: E402
+from olah.utils.cache_utils import write_cache_request  # noqa: E402
+
 
 def test_make_dirs_creates_parent_directories_for_file_paths(tmp_path):
-    target_file = tmp_path / "nested" / "path" / "file.txt"
-
-    make_dirs(str(target_file))
-
-    assert target_file.parent.is_dir()
+    target = tmp_path / "nested" / "path" / "file.txt"
+    make_dirs(str(target))
+    assert target.parent.is_dir()
 
 
-def test_get_folder_size_and_sort_helpers_cover_nested_files(tmp_path):
+def test_get_folder_size_sums_nested_files(tmp_path):
     small = tmp_path / "small.txt"
     medium = tmp_path / "nested" / "medium.txt"
-    large = tmp_path / "nested" / "deep" / "large.txt"
     make_dirs(str(medium))
-    make_dirs(str(large))
-
     small.write_bytes(b"a")
     medium.write_bytes(b"bb")
-    large.write_bytes(b"ccc")
-
-    os.utime(small, (10, 10))
-    os.utime(medium, (20, 20))
-    os.utime(large, (30, 30))
-
-    assert get_folder_size(str(tmp_path)) == 6
-    assert [path for path, _ in sort_files_by_size(str(tmp_path))] == [
-        str(small),
-        str(medium),
-        str(large),
-    ]
-    assert [path for path, _ in sort_files_by_access_time(str(tmp_path))] == [
-        str(small),
-        str(medium),
-        str(large),
-    ]
-    assert [path for path, _ in sort_files_by_modify_time(str(tmp_path))] == [
-        str(small),
-        str(medium),
-        str(large),
-    ]
-
-
-def test_touch_file_access_time_updates_only_atime(tmp_path):
-    target = tmp_path / "data.bin"
-    target.write_bytes(b"payload")
-    os.utime(target, (100, 50))
-
-    before = os.stat(target)
-    touch_file_access_time(str(target))
-    after = os.stat(target)
-
-    assert after.st_mtime == before.st_mtime
-    assert after.st_atime >= before.st_atime
+    assert get_folder_size(str(tmp_path)) == 3
 
 
 def test_convert_size_helpers_handle_supported_units_and_invalid_values():
     assert convert_to_bytes("128") == 128
     assert convert_to_bytes("2KB") == 2 * 1024
     assert convert_to_bytes("3 mb") == 3 * 1024**2
-    assert convert_to_bytes("4T") == 4 * 1024**4
     assert convert_to_bytes(None) is None
     assert convert_to_bytes(4096) == 4096
     assert convert_to_bytes("invalid") is None
 
     assert convert_bytes_to_human_readable(512) == "512.00 B"
     assert convert_bytes_to_human_readable(2048) == "2.00 KB"
+
+
+# ---------------------------------------------------------------------------
+# Eviction
+# ---------------------------------------------------------------------------
+
+def _make_entry(repos_path: str, name: str, payload: bytes, block_size: int, etag: str) -> str:
+    """Create a populated block-cache entry under <repos>/files/<name>."""
+    sp = os.path.join(repos_path, "files", name)
+    c = OlahCache(
+        sp, file_size=len(payload), block_size=block_size,
+        chunk_size=block_size, expected_etag=etag,
+    )
+
+    async def _fill():
+        for i in range((len(payload) + block_size - 1) // block_size):
+            chunk = payload[i * block_size:(i + 1) * block_size]
+            await c.write_block(i, chunk + b"\x00" * (block_size - len(chunk)))
+
+    asyncio.run(_fill())
+    c.close()
+    return sp
+
+
+def test_collect_cache_units_attributes_entries_and_json_sidecars(tmp_path):
+    repos = str(tmp_path / "repos")
+    payload = bytes((i * 7) % 256 for i in range(64))
+    _make_entry(repos, "a", payload, 64, "etag-a")
+
+    jp = os.path.join(repos, "api", "models", "o", "r", "revision", "main", "meta_get.json")
+    asyncio.run(write_cache_request(jp, 200, {"x": "y"}, b"body-bytes!"))
+
+    total, units = collect_cache_units(repos)
+    entries = [u for u in units if u["kind"] == "entry"]
+    jsons = [u for u in units if u["kind"] == "json"]
+    assert len(entries) == 1
+    assert len(jsons) == 1
+    # The JSON unit folds in its .body sidecar (not double-counted as its own unit).
+    assert jsons[0]["size"] == os.path.getsize(jp) + os.path.getsize(jp + ".body")
+    assert entries[0]["size"] > 0
+
+
+def test_evict_removes_whole_oldest_entry_and_keeps_newer(tmp_path):
+    repos = str(tmp_path / "repos")
+    payload = bytes((i * 7) % 256 for i in range(64))
+    sp_old = _make_entry(repos, "old", payload, 64, "etag-old")
+    sp_new = _make_entry(repos, "new", payload, 64, "etag-new")
+    # meta.lock mtime is the LRU signal; force a deterministic order.
+    os.utime(os.path.join(sp_old, "meta.lock"), (1000, 1000))
+    os.utime(os.path.join(sp_new, "meta.lock"), (2000, 2000))
+
+    _, units = collect_cache_units(repos)
+    new_size = next(u["size"] for u in units if u["path"] == sp_new)
+    # Limit = newer entry's size: the older entry must go, the newer stays.
+    evict_cache_to_limit(repos, new_size, "LRU")
+
+    assert not os.path.exists(sp_old), "oldest entry must be removed wholesale"
+    assert not os.path.exists(os.path.join(sp_old, "meta.bin")), "no stray meta.bin"
+    assert os.path.exists(sp_new), "newer entry must remain"
+
+
+def test_evict_skips_entry_whose_meta_lock_is_held(tmp_path):
+    repos = str(tmp_path / "repos")
+    payload = bytes((i * 7) % 256 for i in range(64))
+    sp = _make_entry(repos, "held", payload, 64, "etag-held")
+
+    # Hold a lock on meta.lock as a worker mid open/create/resize would.
+    fh = open(os.path.join(sp, "meta.lock"), "a+")
+    portalocker.lock(fh, portalocker.LOCK_SH | portalocker.LOCK_NB)
+    try:
+        evict_cache_to_limit(repos, 0, "LRU")  # would otherwise evict everything
+        assert os.path.exists(sp), "an entry whose meta.lock is held must not be evicted"
+    finally:
+        portalocker.unlock(fh)
+        fh.close()
+
+
+def test_evict_removes_api_json_and_its_body_sidecar(tmp_path):
+    repos = str(tmp_path / "repos")
+    jp = os.path.join(repos, "api", "models", "o", "r", "revision", "main", "meta_get.json")
+    asyncio.run(write_cache_request(jp, 200, {"x": "y"}, b"body-bytes"))
+    assert os.path.exists(jp) and os.path.exists(jp + ".body")
+
+    evict_cache_to_limit(repos, 0, "LRU")
+
+    assert not os.path.exists(jp)
+    assert not os.path.exists(jp + ".body")

--- a/tests/test_proxy_files.py
+++ b/tests/test_proxy_files.py
@@ -1,4 +1,5 @@
 import importlib
+import importlib.util
 import gzip
 import json
 import sys
@@ -14,7 +15,12 @@ from olah.proxy.result import ProxyResult, single_chunk_body
 
 def _load_proxy_files_module():
     sys.modules.pop("olah.proxy.files", None)
-    if "portalocker" not in sys.modules:
+    # Only inject the no-op stub when portalocker genuinely isn't installed
+    # (e.g. the base conda env). In envs with real portalocker (olah-e2e) we use
+    # the real thing -- never poison sys.modules globally with the stub, or it
+    # leaks into sibling test modules (e.g. test_concurrency) that need real
+    # fcntl.flock mutual exclusion.
+    if importlib.util.find_spec("portalocker") is None:
         portalocker_stub = types.ModuleType("portalocker")
 
         class _Lock:
@@ -112,6 +118,10 @@ def test_get_contiguous_ranges_splits_cached_and_remote_segments():
         def has_block(self, idx):
             return idx == 1
 
+        # get_contiguous_ranges consults the bitmap-backed method; mirror has_block.
+        def is_block_cached(self, idx):
+            return idx == 1
+
     assert proxy_files.get_contiguous_ranges(FakeCache(), 0, 12) == [
         ((0, 4), True),
         ((4, 8), False),
@@ -137,7 +147,6 @@ async def test_file_realtime_stream_returns_invalid_data_error_on_bad_pathsinfo(
         repo="demo",
         file_path="file.bin",
         save_path=str(tmp_path / "save"),
-        head_path=str(tmp_path / "head"),
         url="http://localhost/file.bin",
         request=_make_request(),
         method="GET",
@@ -170,7 +179,6 @@ async def test_file_realtime_stream_handles_empty_and_ambiguous_pathsinfo(monkey
             repo="demo",
             file_path="file.bin",
             save_path=str(tmp_path / "save"),
-            head_path=str(tmp_path / "head"),
             url="http://localhost/file.bin",
             request=_make_request(),
             method="GET",
@@ -231,7 +239,6 @@ async def test_file_realtime_stream_builds_headers_and_streams_get_chunks(monkey
         repo="demo",
         file_path="file.bin",
         save_path=str(tmp_path / "save"),
-        head_path=str(tmp_path / "head"),
         url="https://mirror.example/file.bin?download=1",
         request=_make_request("GET", headers={"range": "bytes=2-5", "authorization": "Bearer t", "host": "mirror.example"}),
         method="GET",
@@ -279,7 +286,6 @@ async def test_file_realtime_stream_uses_head_stream_for_head_requests(monkeypat
         repo="demo",
         file_path="file.bin",
         save_path=str(tmp_path / "save"),
-        head_path=str(tmp_path / "head"),
         url="https://huggingface.co/team/demo/resolve/main/file.bin",
         request=_make_request("HEAD"),
         method="HEAD",
@@ -322,7 +328,6 @@ async def test_file_realtime_stream_without_repo_context_uses_remote_metadata(mo
     result = await proxy_files._file_realtime_stream(
         app=_make_app(tmp_path),
         save_path=str(tmp_path / "save"),
-        head_path=str(tmp_path / "head"),
         url="https://mirror.example/team/demo/hash.bin",
         request=_make_request("GET", headers={"authorization": "Bearer t", "host": "mirror.example"}),
         method="GET",
@@ -349,7 +354,6 @@ async def test_file_realtime_stream_returns_proxy_timeout_when_metadata_lookup_f
     result = await proxy_files._file_realtime_stream(
         app=_make_app(tmp_path),
         save_path=str(tmp_path / "save"),
-        head_path=str(tmp_path / "head"),
         url="https://mirror.example/team/demo/hash.bin",
         request=_make_request("GET", headers={"host": "mirror.example"}),
         method="GET",
@@ -454,7 +458,6 @@ async def test_file_realtime_stream_builds_multipart_response_for_multiple_range
         repo="demo",
         file_path="file.bin",
         save_path=str(tmp_path / "save"),
-        head_path=str(tmp_path / "head"),
         url="https://mirror.example/file.bin",
         request=_make_request("GET", headers={"range": "bytes=0-1,4-5", "host": "mirror.example"}),
         method="GET",
@@ -505,7 +508,6 @@ async def test_file_realtime_stream_rejects_unsatisfiable_ranges(monkeypatch, tm
         repo="demo",
         file_path="file.bin",
         save_path=str(tmp_path / "save"),
-        head_path=str(tmp_path / "head"),
         url="https://mirror.example/file.bin",
         request=_make_request("GET", headers={"range": "bytes=5-9", "host": "mirror.example"}),
         method="GET",
@@ -722,7 +724,6 @@ async def test_file_chunk_get_persists_single_block_files(tmp_path):
         async for chunk in proxy_files._file_chunk_get(
             app=_make_app(tmp_path),
             save_path=str(save_path),
-            head_path=str(tmp_path / "head"),
             client=FakeClient(),
             method="GET",
             url="https://huggingface.co/team/demo/resolve/main/tiny.json",
@@ -762,7 +763,7 @@ async def test_file_chunk_get_streams_from_cache_without_touching_upstream(tmp_p
         def stream(self, **kwargs):
             raise AssertionError("cache hit must not reach upstream")
 
-    common = dict(app=_make_app(tmp_path), save_path=str(save_path), head_path=str(tmp_path / "head"),
+    common = dict(app=_make_app(tmp_path), save_path=str(save_path), 
                   client=FailClient(), method="GET", url="https://x/team/demo/resolve/main/blob.bin",
                   allow_cache=True, file_size=len(payload))
 

--- a/tests/test_zero_length_files.py
+++ b/tests/test_zero_length_files.py
@@ -66,7 +66,6 @@ def test_file_realtime_stream_handles_zero_length_head(monkeypatch, tmp_path):
             repo="NVIDIA-Nemotron-3-Super-120B-A12B-FP8",
             file_path="__init__.py",
             save_path=str(tmp_path / "save"),
-            head_path=str(tmp_path / "head"),
             url="http://127.0.0.1:18090/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8/resolve/main/__init__.py",
             request=_make_request("HEAD"),
             method="HEAD",


### PR DESCRIPTION
## Summary

Fixes the second round of review findings on the v10 block cache: performance hotspots, an unsafe/broken eviction subsystem, a non-atomic hex-doubled JSON request cache, and accumulated dead code. No on-disk format change for the block cache; sync `OlahCache` API unchanged.

### Performance
- **Syscall storm**: `has_block` cost 2 stats per block and `get_contiguous_ranges`/`is_fully_cached` called it per block (~16k stats for a full-file hit on an 8192-block cache). Revives `cache/bitset.py` (previously dead code) as an in-memory presence bitmap built once per `open()` from a **single `os.scandir(blocks/)`**. Bulk iterators consult the bitmap; `has_block` stays disk-authoritative for single-block decisions (read pre-check, single-flight double-check), so bitmap staleness can only cost a redundant download, never corruption.
- `get_block_path`: per-call `string.Template(...).substitute(...)` → f-string.
- `check_disk_usage`: one combined walk (total size **and** eviction candidates) instead of two full-tree walks; dropped the redundant post-cleanup walk; the whole scan+evict is offloaded to `run_in_threadpool` so a TB-scale tree no longer stalls the event loop.
- (Deferred by decision: in-process `OlahCache` instance cache — the bitmap removes the dominant cost; an instance cache would add cross-process invalidation risk for little remaining gain.)

### Eviction correctness
- **Whole-entry granularity**: evicts cache entries (dirs containing `meta.bin`) via `shutil.rmtree`, never individual block files — the old code could delete a block out of `blocks/` mid-request, corrupting the entry and 500-ing clients.
- **Lock-aware**: before removing an entry it probes `LOCK_EX|LOCK_NB` on `meta.lock`; if held (a worker is mid open/create/resize) the entry is skipped.
- **Reliable LRU signal**: FS atime is unusable (`noatime`/`relatime` are the norm, and the old `touch_file_access_time` bumped the *directory* whose atime never propagated to block files — LRU silently degraded to ~FIFO). Now `OlahCache.open` bumps the entry's `meta.lock` **mtime** and `read_cache_request` bumps API-JSON mtime; eviction sorts on mtime. LARGE_FIRST sorts by size.
- **Unbounded metadata**: loose `api/` JSON (with its `.body` sidecar) is now an eviction unit — previously never cleaned.
- **Eviction-resilient reads**: `read_block` returns `None` for a vanished block; `stream_range` surfaces `CacheIntegrityError` (typed, not the old opaque 500) and the proxy falls back to per-block single-flight for the unsent remainder so the client still gets a complete response; a single-flight leader whose entry is evicted mid-download still returns its fetched bytes.

### API request cache (`cache_utils`)
- `write_cache_request` is now **atomic** (tmp+fsync+`os.replace`+fsync dir) — was `open("w")` direct write, which left truncated JSON on crash/concurrent read.
- Body stored **verbatim** in a `<name>.body` sidecar instead of hex-encoded inline JSON (the old `content.hex()` doubled on-disk size). `read_cache_request` prefers the sidecar and transparently falls back to the legacy inline-hex format.

### Dead code
- **`cache/stat.py`** rewritten for v10 (it referenced the long-removed `header.block_mask` and could never run). Prints header fields + block presence from one scandir; optional export when fully cached. Runnable via `python -m olah.cache.stat -f <entry-dir>`.
- **`head_path`** removed everywhere: mkdir'd per request across the file/lfs/xet proxy chain but never written. Removed the `make_dirs` calls, the construction, and the vestigial parameter threaded through 5 internal functions + 2 generators + 13 test call sites.
- `_resize_file_size` confirmed already removed by the v10 refactor — no action.

### Test isolation fix (pre-existing)
`test_proxy_files` injected its no-op portalocker stub whenever portalocker wasn't yet imported, so with explicit file ordering it poisoned `test_concurrency`'s real-`fcntl.flock` assumptions (reproduced on clean `main`). Now gated on `importlib.util.find_spec("portalocker")` — envs with real portalocker never stub it.

## Testing

- Offline suite (olah-e2e env): **130 passed**; only the pre-existing unrelated `test_server_layers` failure remains.
- Live e2e vs real HF (`OLAH_E2E_LIVE=1`): **6 passed** — miss→hit→partial, Qwen3 LFS, Xet direct route, redirect, cache-first+offline.
- New tests: bitmap lifecycle (write/invalidate/reopen/resize), resilient reads, eviction (whole-entry removal, lock-aware skip, api/ json+sidecar, mtime ordering), cache_utils atomicity/sidecar/legacy-compat.
- Manual: `python -m olah.cache.stat` verified on full (`111`) and partial (`101`) caches.
