### PR TITLE
fix: serve canonical repos via paths-info and pass upstream 4xx through

### DIFF
--- a/src/olah/proxy/files.py
+++ b/src/olah/proxy/files.py
@@ -12,7 +12,7 @@ import os
 import time
 from dataclasses import dataclass
 from typing import AsyncIterator, Dict, List, Literal, Optional, Tuple
-from fastapi import Request
+from fastapi import Request, Response
 import fastapi.concurrency
 import httpx
 import portalocker
@@ -640,10 +640,16 @@ async def _remote_file_metadata(
     hf_url: str,
     authorization: Optional[str],
     offline: bool,
-) -> Optional[RemoteFileMetadata]:
+) -> Tuple[Optional[RemoteFileMetadata], Optional[int]]:
+    """Fetch file metadata from the remote. Returns (metadata, upstream status).
+
+    The status code is ``None`` when no upstream response was received (network
+    error). Callers pass 4xx statuses through so clients see the upstream error
+    instead of an opaque 504.
+    """
     if offline:
         etag = await _resource_etag(hf_url=hf_url, authorization=authorization, offline=True)
-        return RemoteFileMetadata(file_size=0, etag=etag)
+        return RemoteFileMetadata(file_size=0, etag=etag), None
 
     headers = {}
     if authorization is not None:
@@ -658,18 +664,21 @@ async def _remote_file_metadata(
                 follow_redirects=True,
             )
     except (httpx.HTTPError, ValueError):
-        return None
+        return None, None
     if response.status_code >= 400:
-        return None
+        return None, response.status_code
 
     content_length = response.headers.get("content-length")
     if content_length is None:
-        return None
+        return None, response.status_code
     try:
         file_size = int(content_length)
     except ValueError:
-        return None
-    return RemoteFileMetadata(file_size=file_size, etag=response.headers.get("etag"))
+        return None, response.status_code
+    return (
+        RemoteFileMetadata(file_size=file_size, etag=response.headers.get("etag")),
+        response.status_code,
+    )
 
 
 def _strip_quotes(value: Optional[str]) -> Optional[str]:
@@ -806,7 +815,9 @@ async def _file_realtime_stream(
     )
     if redirect is not None:
         return redirect
-    if repo_type is not None and org is not None and repo is not None and file_path is not None and commit is not None:
+    # Canonical repos (org=None, e.g. "bert-base-uncased") are ordinary HF
+    # repos; paths-info handles them the same as org/<repo> names.
+    if repo_type is not None and repo is not None and file_path is not None and commit is not None:
         generator = await pathsinfo_generator(
             app,
             repo_type,
@@ -863,13 +874,19 @@ async def _file_realtime_stream(
                 offline=app.state.app_settings.config.offline,
             )
     else:
-        metadata = await _remote_file_metadata(
+        metadata, upstream_status = await _remote_file_metadata(
             app=app,
             hf_url=hf_url,
             authorization=authorization,
             offline=app.state.app_settings.config.offline,
         )
         if metadata is None:
+            # Pass the upstream verdict through: a missing/unauthorized file is
+            # the client's problem, not a proxy timeout.
+            if upstream_status == 404:
+                return await error_result(error_entry_not_found())
+            if upstream_status in (401, 403):
+                return await error_result(Response(status_code=upstream_status))
             return await error_result(error_proxy_timeout())
         file_size = metadata.file_size
         etag = metadata.etag

--- a/tests/test_proxy_files.py
+++ b/tests/test_proxy_files.py
@@ -315,7 +315,7 @@ async def test_file_realtime_stream_without_repo_context_uses_remote_metadata(mo
             "authorization": authorization,
             "offline": offline,
         }
-        return proxy_files.RemoteFileMetadata(file_size=6, etag='"cdn-etag"')
+        return proxy_files.RemoteFileMetadata(file_size=6, etag='"cdn-etag"'), 200
 
     async def fake_file_chunk_get(**kwargs):
         captured["chunk_get"] = kwargs
@@ -347,7 +347,7 @@ async def test_file_realtime_stream_without_repo_context_uses_remote_metadata(mo
 @pytest.mark.asyncio
 async def test_file_realtime_stream_returns_proxy_timeout_when_metadata_lookup_fails(monkeypatch, tmp_path):
     async def fake_remote_file_metadata(*args, **kwargs):
-        return None
+        return None, None
 
     monkeypatch.setattr(proxy_files, "_remote_file_metadata", fake_remote_file_metadata)
 
@@ -364,6 +364,88 @@ async def test_file_realtime_stream_returns_proxy_timeout_when_metadata_lookup_f
     assert result.status_code == 504
     assert result.headers["x-error-code"] == "ProxyTimeout"
     assert body == [b""]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "upstream_status, expected_status, expected_error_code",
+    [(404, 404, "EntryNotFound"), (401, 401, None), (403, 403, None)],
+)
+async def test_file_realtime_stream_passes_through_upstream_client_errors(
+    monkeypatch, tmp_path, upstream_status, expected_status, expected_error_code
+):
+    async def fake_remote_file_metadata(*args, **kwargs):
+        return None, upstream_status
+
+    monkeypatch.setattr(proxy_files, "_remote_file_metadata", fake_remote_file_metadata)
+
+    result = await proxy_files._file_realtime_stream(
+        app=_make_app(tmp_path),
+        save_path=str(tmp_path / "save"),
+        url="https://mirror.example/team/demo/hash.bin",
+        request=_make_request("GET", headers={"host": "mirror.example"}),
+        method="GET",
+        allow_cache=False,
+    )
+    body = [chunk async for chunk in result.body]
+
+    assert result.status_code == expected_status
+    if expected_error_code is not None:
+        assert result.headers["x-error-code"] == expected_error_code
+    assert body == [b""]
+
+
+@pytest.mark.asyncio
+async def test_file_realtime_stream_uses_pathsinfo_for_canonical_repo(monkeypatch, tmp_path):
+    """Canonical repos (org=None, e.g. bert-base-uncased) must take the
+    paths-info branch too, not fall through to _remote_file_metadata."""
+    captured = {}
+
+    async def fail_remote_file_metadata(*args, **kwargs):
+        raise AssertionError("canonical repos should use the pathsinfo branch")
+
+    async def fake_pathsinfo(app, repo_type, org, repo, commit, paths, **kwargs):
+        captured["pathsinfo"] = (repo_type, org, repo, commit, paths)
+        return ProxyResult(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            body=single_chunk_body(
+                json.dumps([{"path": "config.json", "size": 7}])
+            ),
+        )
+
+    async def fake_resource_etag(**kwargs):
+        return '"plain-etag"'
+
+    async def fake_chunk_get(**kwargs):
+        yield b"cfg.data"
+
+    monkeypatch.setattr(proxy_files, "_remote_file_metadata", fail_remote_file_metadata)
+    monkeypatch.setattr(proxy_files, "pathsinfo_generator", fake_pathsinfo)
+    monkeypatch.setattr(proxy_files, "_resource_etag", fake_resource_etag)
+    monkeypatch.setattr(proxy_files, "_file_chunk_get", fake_chunk_get)
+
+    result = await proxy_files._file_realtime_stream(
+        app=_make_app(tmp_path),
+        save_path=str(tmp_path / "save"),
+        url="https://mirror.example/bert-base-uncased/resolve/main/config.json",
+        request=_make_request("GET", headers={"host": "mirror.example"}),
+        method="GET",
+        allow_cache=False,
+        repo_type="models",
+        org=None,
+        repo="bert-base-uncased",
+        file_path="config.json",
+        commit="main",
+    )
+    body = [chunk async for chunk in result.body]
+
+    assert captured["pathsinfo"] == (
+        "models", None, "bert-base-uncased", "main", ["config.json"]
+    )
+    assert result.status_code == 200
+    assert result.headers["content-length"] == "7"
+    assert body == [b"cfg.data"]
 
 
 @pytest.mark.asyncio
@@ -684,7 +766,7 @@ async def test_remote_file_metadata_returns_none_on_http_errors(monkeypatch):
 
     monkeypatch.setattr(proxy_files.httpx, "AsyncClient", FakeAsyncClient)
 
-    metadata = await proxy_files._remote_file_metadata(
+    metadata, status = await proxy_files._remote_file_metadata(
         app=None,
         hf_url="https://remote/file",
         authorization=None,
@@ -692,6 +774,39 @@ async def test_remote_file_metadata_returns_none_on_http_errors(monkeypatch):
     )
 
     assert metadata is None
+    # A transport error means no upstream response at all -> no status to pass
+    # through; the caller reports a proxy timeout.
+    assert status is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("upstream_status", [400, 401, 403, 404, 429])
+async def test_remote_file_metadata_reports_upstream_client_errors(monkeypatch, upstream_status):
+    class FakeResponse:
+        status_code = upstream_status
+        headers = {}
+
+    class FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def request(self, *args, **kwargs):
+            return FakeResponse()
+
+    monkeypatch.setattr(proxy_files.httpx, "AsyncClient", FakeAsyncClient)
+
+    metadata, status = await proxy_files._remote_file_metadata(
+        app=None,
+        hf_url="https://remote/file",
+        authorization=None,
+        offline=False,
+    )
+
+    assert metadata is None
+    assert status == upstream_status
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Reimplementation of #61 (original by @bo0tzz — thanks!) on top of the v10 cache refactor; the original branch conflicted with the `files.py` rewrite in #66/#67, so the two fixes are reapplied here with fresh tests.

Fixes two user-visible misbehaviors for files fetched without LFS context:

1. **Canonical repos were 504-ing.** `_file_realtime_stream` gated the paths-info branch on `org is not None`, so canonical repos (no org, e.g. `bert-base-uncased`, `xlm-roberta-base`) fell through to `_remote_file_metadata`, which HEADs the LFS CDN URL with the repo path appended — the wrong endpoint for these repos. Paths-info handles canonical names fine (HF answers with a 307 that `follow_redirects=True` follows), so the guard is dropped.

2. **Upstream 4xx collapsed into 504.** `_remote_file_metadata` returned `None` for every upstream `>= 400`, which the caller mapped to `504 Proxy Timeout`. Now it returns `(metadata, upstream_status)`:
   - `404` → `404 EntryNotFound`
   - `401` / `403` → passed through verbatim
   - transport errors / unusable responses → still `504`

## Changes

- `src/olah/proxy/files.py`
  - `_remote_file_metadata` returns `Tuple[Optional[RemoteFileMetadata], Optional[int]]` (status is `None` when no upstream response was received)
  - paths-info guard no longer requires `org is not None`
  - caller maps upstream 4xx to the matching client error
- `tests/test_proxy_files.py`
  - upstream client errors pass through as 404/401/403 (parametrized)
  - canonical repo (org=None) takes the paths-info branch (`_remote_file_metadata` monkeypatched to fail if called)
  - `_remote_file_metadata` reports the upstream status for 4xx and `None` only for transport errors

## Testing

- Offline suite in the e2e env: **144 passed, 1 failed** — the single failure is the pre-existing, unrelated `test_run_server_uses_initialized_app_instance` (`server.py:323`, `SimpleNamespace` has no `workers`), which fails identically on `main`.

Closes #61.
