### PR TITLE
fix: tolerate hand-built arg namespaces in run_server

### DIFF
--- a/src/olah/server.py
+++ b/src/olah/server.py
@@ -320,19 +320,24 @@ Incorrect settings may result in unintended file deletion and loss!!! !!!
 def run_server(args):
     import uvicorn
 
-    if args.workers > 1:
+    # ``workers``/``config``/``log_path`` may be absent on hand-built argument
+    # namespaces (tests, programmatic callers); the argparse defaults are
+    # single-process, no config file, ./logs.
+    workers = getattr(args, "workers", 1)
+    if workers > 1:
         # Multi-worker: uvicorn spawns worker processes that re-import this
         # module, so config must come from a file (passed via OLAH_CONFIG) rather
         # than CLI args. The cache dir is multi-process safe (portalocker locks).
-        if not args.config:
+        config_path = getattr(args, "config", "")
+        if not config_path:
             raise ValueError("--workers > 1 requires --config <toml>; each worker re-reads it.")
-        os.environ["OLAH_CONFIG"] = args.config
-        os.environ.setdefault("OLAH_LOG_PATH", args.log_path)
+        os.environ["OLAH_CONFIG"] = config_path
+        os.environ.setdefault("OLAH_LOG_PATH", getattr(args, "log_path", "./logs"))
         uvicorn.run(
             "olah.server:app",
             host=args.host,
             port=args.port,
-            workers=args.workers,
+            workers=workers,
             log_level="info",
             reload=False,
             ssl_keyfile=args.ssl_key,

--- a/tests/test_server_layers.py
+++ b/tests/test_server_layers.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import types
 from types import SimpleNamespace
@@ -349,6 +350,8 @@ def test_run_server_uses_initialized_app_instance(monkeypatch):
 
     server_module = importlib.import_module("olah.server")
     calls = {}
+    # No `workers` attribute on purpose: programmatic callers / older namespaces
+    # must fall back to the single-process branch, not crash.
     args = SimpleNamespace(host="127.0.0.1", port=8090, ssl_key=None, ssl_cert=None)
     server_module.app.state.app_settings = server_module.AppSettings()
 
@@ -364,6 +367,55 @@ def test_run_server_uses_initialized_app_instance(monkeypatch):
     assert hasattr(calls["app"].state, "app_settings")
     assert calls["kwargs"]["host"] == "127.0.0.1"
     assert calls["kwargs"]["port"] == 8090
+    assert "workers" not in calls["kwargs"]  # single-process: app object, no workers kwarg
+
+
+def test_run_server_multi_worker_requires_config(monkeypatch):
+    import importlib
+
+    server_module = importlib.import_module("olah.server")
+    args = SimpleNamespace(
+        host="127.0.0.1", port=8090, ssl_key=None, ssl_cert=None,
+        workers=4, config="", log_path="./logs",
+    )
+
+    with pytest.raises(ValueError, match="requires --config"):
+        server_module.run_server(args)
+
+
+def test_run_server_multi_worker_imports_app_and_sets_env(monkeypatch):
+    import importlib
+
+    server_module = importlib.import_module("olah.server")
+    calls = {}
+    args = SimpleNamespace(
+        host="127.0.0.1", port=8090, ssl_key=None, ssl_cert=None,
+        workers=4, config="/tmp/olah-test.toml", log_path="./test-logs",
+    )
+    env_before = {k: os.environ.get(k) for k in ("OLAH_CONFIG", "OLAH_LOG_PATH")}
+    monkeypatch.delenv("OLAH_CONFIG", raising=False)
+    monkeypatch.delenv("OLAH_LOG_PATH", raising=False)
+
+    def fake_run(app, **kwargs):
+        calls["app"] = app
+        calls["kwargs"] = kwargs
+
+    monkeypatch.setattr("uvicorn.run", fake_run)
+
+    try:
+        server_module.run_server(args)
+
+        # Multi-worker mode runs the import string, not the in-process app.
+        assert calls["app"] == "olah.server:app"
+        assert calls["kwargs"]["workers"] == 4
+        assert os.environ["OLAH_CONFIG"] == "/tmp/olah-test.toml"
+        assert os.environ["OLAH_LOG_PATH"] == "./test-logs"
+    finally:
+        for key, value in env_before.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 def test_build_logger_redirects_stdout_and_stderr_only_once(tmp_path):


### PR DESCRIPTION
## Summary

Fixes the long-standing `test_run_server_uses_initialized_app_instance` failure — the only red test left in the suite.

**Root cause:** `run_server` accessed `args.workers` / `args.config` / `args.log_path` unconditionally, but `--workers` (and friends) are newer CLI options than the function's other callers. The test builds its namespace by hand without them → `AttributeError: 'SimpleNamespace' object has no attribute 'workers'` at `server.py:323`.

**Fix (root, not symptom):** read the three optional attributes via `getattr` with the argparse defaults — missing attribute means exactly what it means on the command line: single process, no config file, `./logs`. `run_server` keeps its contract for programmatic callers and tests instead of requiring every namespace to mirror the full CLI surface.

**Bonus:** the multi-worker branch (added with `--workers` in #65) had zero test coverage. Two new tests:
- `--workers > 1` without `--config` raises `ValueError`
- with `--config`, uvicorn receives the `"olah.server:app"` import string + `workers` kwarg, and `OLAH_CONFIG` / `OLAH_LOG_PATH` are exported for the re-importing worker processes

## Testing

Full offline suite: **147 passed, 0 failed** — fully green for the first time since the v10 cache work landed.
