### PR TITLE
fix: do not map Hub rate-limits or redirects to repo-not-found

### DIFF
--- a/src/olah/utils/repo_utils.py
+++ b/src/olah/utils/repo_utils.py
@@ -21,6 +21,12 @@ from olah.utils.cache_utils import read_cache_request
 
 logger = logging.getLogger(__name__)
 
+# Hub HEAD /api/{type}/{repo} is used as a visibility probe on every client
+# request. huggingface_hub treats our 401 RepoNotFound as "model does not
+# exist", so rate-limits and redirects must not be mapped onto that.
+_HF_VISIBILITY_OK = {200, 301, 302, 303, 307, 308}
+_HF_VISIBILITY_RETRY = {408, 425, 429}
+
 
 def _content_encoding_is_gzip(headers: object) -> bool:
     """Return True if the cached response headers advertise gzip content-encoding.
@@ -416,9 +422,11 @@ async def check_commit_hf(
         authorization: The authorization token (optional).
 
     Returns:
-        True if the commit is valid (status code 200 or 307), False if the
-        upstream rejected it (other non-5xx status), or None if the upstream
-        could not be reached (transport error or 5xx response).
+        True if the commit is valid (2xx or redirect), False if the
+        upstream rejected it (other non-retryable status), or None if the
+        upstream could not be reached (transport error, 429, or 5xx).
+        None is retried by the decorator; callers map it to HTTP 504 rather
+        than 401 so huggingface_hub does not treat a blip as "repo not found".
 
     """
     org_repo = get_org_repo(org, repo)
@@ -436,7 +444,7 @@ async def check_commit_hf(
     if authorization is not None:
         headers["authorization"] = authorization
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
             response = await client.request(
                 method="HEAD",
                 url=url,
@@ -447,6 +455,6 @@ async def check_commit_hf(
     except httpx.HTTPError as e:
         logger.warning("Upstream request failed while checking %s: %r", url, e)
         return None
-    if status_code >= 500:
+    if status_code in _HF_VISIBILITY_RETRY or status_code >= 500:
         return None
-    return status_code in [200, 307]
+    return status_code in _HF_VISIBILITY_OK

--- a/tests/test_repo_utils.py
+++ b/tests/test_repo_utils.py
@@ -245,12 +245,15 @@ def test_get_newest_commit_hf_falls_back_to_offline_on_connect_error(monkeypatch
     assert commit == "offline-sha"
 
 
-def _make_fake_client(monkeypatch, *, status_code=None, error=None, calls=None):
+def _make_fake_client(monkeypatch, *, status_code=None, error=None, calls=None, handler=None):
     class FakeResponse:
-        def __init__(self):
-            self.status_code = status_code
+        def __init__(self, code):
+            self.status_code = code
 
     class FakeAsyncClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
         async def __aenter__(self):
             return self
 
@@ -258,11 +261,14 @@ def _make_fake_client(monkeypatch, *, status_code=None, error=None, calls=None):
             return False
 
         async def request(self, *args, **kwargs):
+            headers = kwargs.get("headers") or {}
             if calls is not None:
-                calls.append(kwargs.get("url") or args)
+                calls.append({"url": kwargs.get("url") or (args[1] if len(args) > 1 else args), "headers": dict(headers)})
             if error is not None:
                 raise error
-            return FakeResponse()
+            if handler is not None:
+                return FakeResponse(handler(headers))
+            return FakeResponse(status_code)
 
     monkeypatch.setattr(repo_utils.httpx, "AsyncClient", FakeAsyncClient)
 
@@ -295,3 +301,38 @@ def test_check_commit_hf_distinguishes_upstream_yes_and_no(monkeypatch, tmp_path
 
     _make_fake_client(monkeypatch, status_code=401)
     assert asyncio.run(repo_utils.check_commit_hf(app, "models", "team", "demo")) is False
+
+
+def test_check_commit_hf_treats_redirects_as_visible(monkeypatch, tmp_path):
+    app = _make_app(tmp_path, offline=False)
+    _make_fake_client(monkeypatch, status_code=302)
+    assert asyncio.run(repo_utils.check_commit_hf(app, "models", "team", "demo")) is True
+
+
+def test_check_commit_hf_returns_none_on_rate_limit(monkeypatch, tmp_path):
+    app = _make_app(tmp_path, offline=False)
+    calls = []
+    _make_fake_client(monkeypatch, status_code=429, calls=calls)
+    assert asyncio.run(repo_utils.check_commit_hf(app, "models", "team", "demo")) is None
+    assert len(calls) == 3
+
+
+def test_check_commit_hf_does_not_retry_anonymously_when_token_is_rejected(monkeypatch, tmp_path):
+    """Match huggingface_hub: a rejected token is a hard 401, even for public repos."""
+    app = _make_app(tmp_path, offline=False)
+    calls = []
+
+    def handler(headers):
+        if any(k.lower() == "authorization" for k in headers):
+            return 401
+        return 200
+
+    _make_fake_client(monkeypatch, handler=handler, calls=calls)
+    ok = asyncio.run(
+        repo_utils.check_commit_hf(
+            app, "models", "team", "demo", authorization="Bearer hf_bogus"
+        )
+    )
+    assert ok is False
+    assert len(calls) == 1
+    assert calls[0]["headers"].get("authorization") == "Bearer hf_bogus"


### PR DESCRIPTION
Visibility HEADs only counted 200/307 as an existing repo. huggingface_hub turns our 401 into "model does not exist", so a 429 or an unfollowed redirect aborted downloads (including optional tokenizer files).

Follow redirects, treat 429/408/425 like 5xx (retry, then 504), and leave a rejected token as a hard 401.